### PR TITLE
feat: global publish method

### DIFF
--- a/docs/1.guide/5.pubsub.md
+++ b/docs/1.guide/5.pubsub.md
@@ -35,3 +35,7 @@ const hooks = defineHooks({
   },
 });
 ```
+
+## Publish without peer
+
+To publish messages without a peer, the [Bun](/adapters/bun) and [Node.js](http://localhost:4000/adapters/node) adapters expose a `publish` method.

--- a/docs/2.adapters/bun.md
+++ b/docs/2.adapters/bun.md
@@ -8,16 +8,18 @@ icon: simple-icons:bun
 
 To integrate CrossWS with your Bun server, you need to handle upgrade with `handleUpgrade` util and also pass the `websocket` object returned from the adapter to server options. CrossWS leverages native Bun WebSocket API.
 
+If you wish to [publish](/guide/pubsub) messages without a Peer, you will need to provide the CrossWS adapter with a reference to your Bun server using `setPublishingServer`.
+
 ```ts
 import wsAdapter from "crossws/adapters/bun";
 
-const { websocket, handleUpgrade } = wsAdapter({
+const { websocket, handleUpgrade, setPublishingServer, publish } = wsAdapter({
   hooks: {
     message: console.log,
   },
 });
 
-Bun.serve({
+const server = Bun.serve({
   port: 3000,
   websocket,
   fetch(req, server) {
@@ -30,6 +32,8 @@ Bun.serve({
     );
   },
 });
+
+setPublishingServer(server);
 ```
 
 ## Adapter Hooks

--- a/docs/2.adapters/node.md
+++ b/docs/2.adapters/node.md
@@ -79,5 +79,5 @@ server.listen(3001, () => {
 - `uws:subscription (ws, topic, newCount, oldCount)`
 
 ::read-more
-See [`playground/node-uws.ts`](https://github.com/unjs/crossws/tree/main/playground/node-uws.ts) for demo and [`src/adapters/node-uws.ts`](https://github.com/unjs/crossws/tree/main/src/adapters/node-uws.ts) for implementation.
+See [`playground/uws.ts`](https://github.com/unjs/crossws/tree/main/playground/uws.ts) for demo and [`src/adapters/uws.ts`](https://github.com/unjs/crossws/tree/main/src/adapters/uws.ts) for implementation.
 ::

--- a/docs/2.adapters/node.md
+++ b/docs/2.adapters/node.md
@@ -8,6 +8,8 @@ icon: akar-icons:node-fill
 
 To integrate CrossWS with your Node.js HTTP server, you need to connect the `upgrade` event to the `handleUpgrade` method returned from the adapter. CrossWS uses a prebundled version of [ws](https://github.com/websockets/ws).
 
+The Node adapter supports [publishing](/guide/pubsub) messages without a Peer, using the `publish` method in the wsAdapter.
+
 ```ts
 import { createServer } from "node:http";
 import wsAdapter from "crossws/adapters/node";
@@ -18,7 +20,7 @@ const server = createServer((req, res) => {
   );
 }).listen(3000);
 
-const { handleUpgrade } = wsAdapter({ message: console.log });
+const { handleUpgrade, publish } = wsAdapter({ message: console.log });
 server.on("upgrade", handleUpgrade);
 ```
 
@@ -43,17 +45,21 @@ Integrate CrossWS with Node.js using uWebSockets.js.
 
 Instead of [using `ws`](/adapters/node-ws) you can use [uWebSockets.js](https://github.com/uNetworking/uWebSockets.js) for Node.js servers.
 
+If you wish to [publish](/guide/pubsub) messages without a Peer, you will need to provide the CrossWS adapter with a reference to the uWebSocket.js TemplatedApp using `setPublishingApp`.
+
 ```ts
 import { App } from "uWebSockets.js";
 import wsAdapter from "crossws/adapters/uws";
 
-const { websocket } = wsAdapter({
+const { websocket, setPublishingApp, publish } = wsAdapter({
   hooks: {
     message: console.log,
   },
 });
 
 const server = App().ws("/*", websocket);
+
+setPublishingApp(app);
 
 server.get("/*", (res, req) => {
   res.writeStatus("200 OK").writeHeader("Content-Type", "text/html");

--- a/playground/bun.ts
+++ b/playground/bun.ts
@@ -3,9 +3,9 @@
 import bunAdapter from "../src/adapters/bun";
 import { createDemo, getIndexHTML } from "./_shared";
 
-const { websocket, handleUpgrade } = createDemo(bunAdapter);
+const { websocket, handleUpgrade, setPublishingServer } = createDemo(bunAdapter);
 
-Bun.serve({
+const server = Bun.serve({
   port: 3001,
   websocket,
   async fetch(req, server) {
@@ -17,3 +17,5 @@ Bun.serve({
     });
   },
 });
+
+setPublishingServer(server);

--- a/playground/uws.ts
+++ b/playground/uws.ts
@@ -8,6 +8,8 @@ const adapter = createDemo(uwsAdapter);
 
 const app = App().ws("/*", adapter.websocket);
 
+adapter.setPublishingApp(app);
+
 app.get("/*", async (res, req) => {
   let aborted = false;
   res.onAborted(() => {

--- a/playground/uws.ts
+++ b/playground/uws.ts
@@ -1,4 +1,4 @@
-// You can run this demo using `npm run play:node-uws` in repo
+// You can run this demo using `npm run play:uws` in repo
 
 import { App } from "uWebSockets.js";
 import uwsAdapter from "../src/adapters/uws";


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

resolves #29 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Provides means for the crossws adapters that support pub/sub (bun, node and uws) to publish to a topic without holding onto a Peer. This will help support messages being initiated from other server contexts - rather than just in response to a Peer.

Open to input on alternative approaches - I expect this might not be _quite_ at the desired quality just yet.

Not clear how this proposed feature would best integrate into downstream packages like h3 or Nitro. Open to any discussion!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
