### PR TITLE
feat(node, uws): automatically detect binary message type

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "listhen": "^1.7.2",
     "prettier": "^3.3.3",
     "typescript": "^5.5.4",
-    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.33.0",
+    "uWebSockets.js": "github:uNetworking/uWebSockets.js#v20.44.0",
     "unbuild": "^2.0.0",
     "vitest": "^2.0.0",
     "wrangler": "^3.67.1",

--- a/playground/_index.html.ts
+++ b/playground/_index.html.ts
@@ -73,10 +73,11 @@ export default /* html */ `
         log("ws", "Connecting to", url, "...");
         ws = new WebSocket(url);
 
-        ws.addEventListener("message", (event) => {
-          const { user = "system", message = "" } = event.data.startsWith("{")
-            ? JSON.parse(event.data)
-            : { message: event.data };
+        ws.addEventListener("message", async (event) => {
+          const data = typeof event.data === "string" ? event.data : await event.data.text();
+          const { user = "system", message = "" } = data.startsWith("{")
+            ? JSON.parse(data)
+            : { message: data };
           log(
             user,
             typeof message === "string" ? message : JSON.stringify(message),

--- a/playground/_shared.ts
+++ b/playground/_shared.ts
@@ -11,6 +11,7 @@ export function createDemo<T extends Adapter<any, any>>(
     open(peer) {
       console.log(`[ws] open ${peer}`);
       peer.send({ user: "server", message: `Welcome to the server ${peer}!` });
+      peer.send(new TextEncoder().encode("(binary message works!)"));
       peer.subscribe("chat");
       peer.publish("chat", { user: "server", message: `${peer} joined!` });
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -63,8 +63,8 @@ importers:
         specifier: ^5.5.4
         version: 5.5.4
       uWebSockets.js:
-        specifier: github:uNetworking/uWebSockets.js#v20.33.0
-        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/c10b47c350cc97c299c6b4a07a98abb628704c71
+        specifier: github:uNetworking/uWebSockets.js#v20.44.0
+        version: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/8fa05571bf6ea95be8966ad313d9d39453e381ae
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.5.4)
@@ -2912,9 +2912,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/c10b47c350cc97c299c6b4a07a98abb628704c71:
-    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/c10b47c350cc97c299c6b4a07a98abb628704c71}
-    version: 20.33.0
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/8fa05571bf6ea95be8966ad313d9d39453e381ae:
+    resolution: {tarball: https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/8fa05571bf6ea95be8966ad313d9d39453e381ae}
+    version: 20.44.0
 
   ufo@1.5.4:
     resolution: {integrity: sha512-UsUk3byDzKd04EyoZ7U4DOlxQaD14JUKQl6/P7wiX4FNvUfm3XL246n9W5AmqwW5RSFJ27NAuM0iLscAOYUiGQ==}
@@ -5833,7 +5833,7 @@ snapshots:
 
   typescript@5.5.4: {}
 
-  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/c10b47c350cc97c299c6b4a07a98abb628704c71: {}
+  uWebSockets.js@https://codeload.github.com/uNetworking/uWebSockets.js/tar.gz/8fa05571bf6ea95be8966ad313d9d39453e381ae: {}
 
   ufo@1.5.4: {}
 

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -5,8 +5,18 @@ export function toBufferLike(val: any): BufferLike {
     return "";
   }
 
-  if (typeof val === "string") {
+  const type = typeof val;
+
+  if (type === "string") {
     return val;
+  }
+
+  if (type === "number" || type === "boolean" || type === "bigint") {
+    return val.toString();
+  }
+
+  if (type === "function" || type === "symbol") {
+    return "{}";
   }
 
   if (val instanceof Uint8Array || val instanceof ArrayBuffer) {

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -174,24 +174,20 @@ class UWSPeer extends Peer<{
     return this._headers;
   }
 
-  send(message: any, options?: { compress?: boolean; binary?: boolean }) {
-    return this.ctx.uws.ws.send(
-      toBufferLike(message),
-      options?.binary,
-      options?.compress,
-    );
+  send(message: any, options?: { compress?: boolean }) {
+    const data = toBufferLike(message);
+    const isBinary = typeof data !== "string";
+    return this.ctx.uws.ws.send(data, isBinary, options?.compress);
   }
 
   subscribe(topic: string): void {
     this.ctx.uws.ws.subscribe(topic);
   }
 
-  publish(
-    topic: string,
-    message: string,
-    options?: { compress?: boolean; binary?: boolean },
-  ) {
-    this.ctx.uws.ws.publish(topic, message, options?.binary, options?.compress);
+  publish(topic: string, message: string, options?: { compress?: boolean }) {
+    const data = toBufferLike(message);
+    const isBinary = typeof data !== "string";
+    this.ctx.uws.ws.publish(topic, data, isBinary, options?.compress);
     return 0;
   }
 }


### PR DESCRIPTION
resolves #37 (followup on #39)

Node and UWS expect to explicitly flag binary responses. This PR fixes this by simple `typeof` check also adds more type compact for number/boolean types