### PR TITLE
feat(deno): support pubsub

### DIFF
--- a/docs/1.guide/5.pubsub.md
+++ b/docs/1.guide/5.pubsub.md
@@ -6,9 +6,6 @@ icon: simple-icons:googlepubsub
 
 CrossWS supports native pub-sub API integration. A [peer](/guide/peer) can be subscribed to a set of named channels using `peer.subscribe(<name>)`. Messages can be published to a channel using `peer.publish(<name>, <message>)`.
 
-> [!IMPORTANT]
-> Native pub/sub is currently only available for [Bun](/adapters/bun), [Node.js (uWebSockets)](/adapters/node#uwebsockets) and [Cloudflare (durable objects)](/adapters/cloudflare).
-
 ```js
 import { defineHooks } from "crossws";
 

--- a/docs/2.adapters/cloudflare.md
+++ b/docs/2.adapters/cloudflare.md
@@ -8,6 +8,9 @@ icon: devicon-plain:cloudflareworkers
 
 To integrate CrossWS with your Cloudflare Workers, you need to check for the `upgrade` header.
 
+> [!IMPORTANT]
+> For [pub/sub](/guide/pubsub) support, you need to use [Durable objects](#durable-objects-support).
+
 ```ts
 import wsAdapter from "crossws/adapters/cloudflare";
 

--- a/test/adapters/deno.test.ts
+++ b/test/adapters/deno.test.ts
@@ -2,5 +2,5 @@ import { describe } from "vitest";
 import { wsTestsExec } from "../_utils";
 
 describe("deno", () => {
-  wsTestsExec("deno run -A ./deno.ts", { pubsub: false, resHeaders: false });
+  wsTestsExec("deno run -A ./deno.ts", { resHeaders: false });
 });


### PR DESCRIPTION
Support pubsub for deno using shared state. (I tried same method for basic pubsub in cloudflare without durable but seems async context tracking cannot allow this)

