### PR TITLE
feat: universal access to all peers

### DIFF
--- a/src/adapters/cloudflare-durable.ts
+++ b/src/adapters/cloudflare-durable.ts
@@ -123,7 +123,6 @@ function peerFromDurableEvent(
     return peer;
   }
   peer = ws._crosswsPeer = new CloudflareDurablePeer({
-    peers: undefined as any, // Intentionally undefined to avoid wrongly using it
     cloudflare: {
       ws: ws as CF.WebSocket,
       request,
@@ -135,7 +134,7 @@ function peerFromDurableEvent(
 }
 
 class CloudflareDurablePeer extends Peer<{
-  peers: Set<CloudflareDurablePeer>; // Won't be used
+  peers?: never;
   cloudflare: {
     ws: AugmentedWebSocket;
     request?: Request | CF.Request;

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -44,6 +44,7 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
         const client = pair[0];
         const server = pair[1];
         const peer = new CloudflarePeer({
+          peers,
           cloudflare: { client, server, request, env, context },
         });
         peers.add(peer);
@@ -76,7 +77,7 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
 );
 
 class CloudflarePeer extends Peer<{
-  peers?: never;
+  peers: Set<CloudflarePeer>;
   cloudflare: {
     client: _cf.WebSocket;
     server: _cf.WebSocket;

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -3,7 +3,11 @@
 import type * as _cf from "@cloudflare/workers-types";
 
 import { Peer } from "../peer";
-import { AdapterOptions, defineWebSocketAdapter } from "../types.js";
+import {
+  AdapterOptions,
+  AdapterInstance,
+  defineWebSocketAdapter,
+} from "../types.js";
 import { Message } from "../message";
 import { WSError } from "../error";
 import { AdapterHookable } from "../hooks.js";
@@ -12,7 +16,7 @@ import { toBufferLike } from "../_utils";
 declare const WebSocketPair: typeof _cf.WebSocketPair;
 declare const Response: typeof _cf.Response;
 
-export interface CloudflareAdapter {
+export interface CloudflareAdapter extends AdapterInstance {
   handleUpgrade(
     req: _cf.Request,
     env: unknown,
@@ -25,7 +29,9 @@ export interface CloudflareOptions extends AdapterOptions {}
 export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
   (options = {}) => {
     const hooks = new AdapterHookable(options);
+    const peers = new Set<CloudflarePeer>();
     return {
+      peers,
       handleUpgrade: async (request, env, context) => {
         const res = await hooks.callHook(
           "upgrade",
@@ -40,6 +46,7 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
         const peer = new CloudflarePeer({
           cloudflare: { client, server, request, env, context },
         });
+        peers.add(peer);
         server.accept();
         hooks.callAdapterHook("cloudflare:accept", peer);
         hooks.callHook("open", peer);
@@ -48,10 +55,12 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
           hooks.callHook("message", peer, new Message(event.data));
         });
         server.addEventListener("error", (event) => {
+          peers.delete(peer);
           hooks.callAdapterHook("cloudflare:error", peer, event);
           hooks.callHook("error", peer, new WSError(event.error));
         });
         server.addEventListener("close", (event) => {
+          peers.delete(peer);
           hooks.callAdapterHook("cloudflare:close", peer, event);
           hooks.callHook("close", peer, event);
         });
@@ -67,6 +76,7 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
 );
 
 class CloudflarePeer extends Peer<{
+  peers?: never;
   cloudflare: {
     client: _cf.WebSocket;
     server: _cf.WebSocket;
@@ -94,6 +104,16 @@ class CloudflarePeer extends Peer<{
   send(message: any) {
     this._internal.cloudflare.server.send(toBufferLike(message));
     return 0;
+  }
+
+  publish(_topic: string, _message: any): void {
+    // Not supported
+    // Throws: A hanging Promise was canceled
+    // for (const peer of this._internal.peers) {
+    //   if (peer !== this && peer._topics.has(_topic)) {
+    //     peer.publish(_topic, _message);
+    //   }
+    // }
   }
 
   close(code?: number, reason?: string) {

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -103,9 +103,7 @@ export default defineWebSocketAdapter<NodeAdapter, NodeOptions>(
     });
 
     return {
-      get peers() {
-        return peers;
-      },
+      peers,
       handleUpgrade: async (req, socket, head) => {
         const res = await hooks.callHook("upgrade", new NodeReqProxy(req));
         if (res instanceof Response) {

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -8,17 +8,21 @@ const ReadyStateMap = {
   3: "closed",
 } as const;
 
-export abstract class Peer<AdapterContext = any> {
-  protected _internal: AdapterContext;
+export interface AdapterInternal {
+  peers?: Set<Peer>;
+}
+
+export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
+  protected _internal: Internal;
   protected _topics: Set<string>;
 
   private static _idCounter = 0;
   private _id: string;
 
-  constructor(_internalCtx: AdapterContext) {
+  constructor(internal: Internal) {
     this._id = ++Peer._idCounter + "";
     this._topics = new Set();
-    this._internal = _internalCtx;
+    this._internal = internal;
   }
 
   get id(): string {
@@ -41,11 +45,17 @@ export abstract class Peer<AdapterContext = any> {
     return -1;
   }
 
+  get peers(): Set<Peer> {
+    return this._internal.peers || new Set();
+  }
+
   abstract send(message: any, options?: { compress?: boolean }): number;
 
-  publish(topic: string, message: any, options?: { compress?: boolean }) {
-    // noop
-  }
+  abstract publish(
+    topic: string,
+    message: any,
+    options?: { compress?: boolean },
+  ): void;
 
   subscribe(topic: string) {
     this._topics.add(topic);

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,9 @@ import type { Peer } from "./peer.ts";
 
 // --- Adapter ---
 
-export interface CrossWSAdapter {}
+export interface AdapterInstance {
+  readonly peers: Set<Peer>;
+}
 
 export interface AdapterOptions {
   resolve?: ResolveHooks;
@@ -13,12 +15,12 @@ export interface AdapterOptions {
 }
 
 export type Adapter<
-  AdapterT extends CrossWSAdapter = CrossWSAdapter,
+  AdapterT extends AdapterInstance = AdapterInstance,
   Options extends AdapterOptions = AdapterOptions,
 > = (options?: Options) => AdapterT;
 
 export function defineWebSocketAdapter<
-  AdapterT extends CrossWSAdapter = CrossWSAdapter,
+  AdapterT extends AdapterInstance = AdapterInstance,
   Options extends AdapterOptions = AdapterOptions,
 >(factory: Adapter<AdapterT, Options>) {
   return factory;

--- a/test/_utils.ts
+++ b/test/_utils.ts
@@ -8,15 +8,24 @@ import { wsTests } from "./tests";
 
 const fixtureDir = fileURLToPath(new URL("fixture", import.meta.url));
 
+const websockets = new Set<WebSocket>();
+afterEach(() => {
+  for (const ws of websockets) {
+    ws.close();
+  }
+  websockets.clear();
+});
+
 export function wsConnect(
   url: string,
   opts?: { skip?: number; headers?: OutgoingHttpHeaders },
 ) {
   const ws = new WebSocket(url, { headers: opts?.headers });
+  websockets.add(ws);
 
   const upgradeHeaders: Record<string, string> = Object.create(null);
 
-  const send = async (data: any) => {
+  const send = async (data: any): Promise<any> => {
     ws.send(
       typeof data === "string" ? data : JSON.stringify({ message: data }),
     );
@@ -53,11 +62,6 @@ export function wsConnect(
       waitCallbacks[index](payload);
       delete waitCallbacks[index];
     }
-  });
-
-  afterEach(() => {
-    ws.removeAllListeners();
-    ws.close();
   });
 
   const res = {

--- a/test/adapters/node.test.ts
+++ b/test/adapters/node.test.ts
@@ -12,7 +12,14 @@ describe("node", () => {
 
   beforeAll(async () => {
     ws = createDemo(nodeAdapter);
-    server = createServer((_req, res) => {
+    server = createServer((req, res) => {
+      if (req.url === "/peers") {
+        return res.end(
+          JSON.stringify({
+            peers: [...ws.peers].map((p) => p.id),
+          }),
+        );
+      }
       res.end("ok");
     });
     server.on("upgrade", ws.handleUpgrade);

--- a/test/adapters/uws.test.ts
+++ b/test/adapters/uws.test.ts
@@ -19,14 +19,19 @@ describe("uws", () => {
       res.onAborted(() => {
         aborted = true;
       });
-      const html = "OK";
+
+      let resBody = "OK";
+      const url = req.getUrl();
+      if (url === "/peers") {
+        resBody = JSON.stringify({ peers: [...ws.peers].map((p) => p.id) });
+      }
+
       if (aborted) {
         return;
       }
       res.cork(() => {
         res.writeStatus("200 OK");
-        res.writeHeader("Content-Type", "text/html");
-        res.end(html);
+        res.end(resBody);
       });
     });
 

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -1,4 +1,4 @@
-import { ResolveHooks, Adapter, defineHooks } from "../../src/index.ts";
+import { Adapter, AdapterInstance, defineHooks } from "../../src/index.ts";
 
 export const getIndexHTML = () =>
   import("./_index.html.ts").then((r) => r.default);
@@ -33,6 +33,12 @@ export function createDemo<T extends Adapter<any, any>>(
           });
           break;
         }
+        case "peers": {
+          peer.send({
+            peers: [...peer.peers].map((p) => p.id),
+          });
+          break;
+        }
         default: {
           peer.send(msgText);
           peer.publish("chat", msgText);
@@ -60,4 +66,18 @@ export function createDemo<T extends Adapter<any, any>>(
     ...options,
     hooks,
   });
+}
+
+export function handleDemoRoutes(
+  ws: AdapterInstance,
+  request: Request,
+): Response | undefined {
+  const url = new URL(request.url);
+  if (url.pathname === "/peers") {
+    return new Response(
+      JSON.stringify({
+        peers: [...ws.peers].map((p) => p.id),
+      }),
+    );
+  }
 }

--- a/test/fixture/bun.ts
+++ b/test/fixture/bun.ts
@@ -1,7 +1,7 @@
 // You can run this demo using `bun --bun ./bun.ts` or `npm run play:bun` in repo
 
 import bunAdapter from "../../src/adapters/bun";
-import { createDemo, getIndexHTML } from "./_shared";
+import { createDemo, getIndexHTML, handleDemoRoutes } from "./_shared";
 
 const ws = createDemo(bunAdapter);
 
@@ -10,6 +10,10 @@ Bun.serve({
   hostname: "localhost",
   websocket: ws.websocket,
   async fetch(request, server) {
+    const response = handleDemoRoutes(ws, request);
+    if (response) {
+      return response;
+    }
     if (request.headers.get("upgrade") === "websocket") {
       return ws.handleUpgrade(request, server);
     }

--- a/test/fixture/cloudflare-durable.ts
+++ b/test/fixture/cloudflare-durable.ts
@@ -1,7 +1,7 @@
 // You can run this demo using `npm run play:cf-durable` in repo
 import { DurableObject } from "cloudflare:workers";
 import cloudflareAdapter from "../../src/adapters/cloudflare-durable.ts";
-import { createDemo, getIndexHTML } from "./_shared.ts";
+import { createDemo, getIndexHTML, handleDemoRoutes } from "./_shared.ts";
 
 const ws = createDemo(cloudflareAdapter);
 
@@ -11,6 +11,11 @@ export default {
     env: Record<string, any>,
     context: ExecutionContext,
   ): Promise<Response> {
+    const response = handleDemoRoutes(ws, request);
+    if (response) {
+      return response;
+    }
+
     if (request.headers.get("upgrade") === "websocket") {
       return ws.handleUpgrade(request, env, context);
     }

--- a/test/fixture/cloudflare.ts
+++ b/test/fixture/cloudflare.ts
@@ -1,7 +1,7 @@
 // You can run this demo using `npm run play:cf` in repo
-import type { Request, ExecutionContext } from "@cloudflare/workers-types";
+import type { ExecutionContext } from "@cloudflare/workers-types";
 import cloudflareAdapter from "../../src/adapters/cloudflare";
-import { createDemo, getIndexHTML } from "./_shared.ts";
+import { createDemo, getIndexHTML, handleDemoRoutes } from "./_shared.ts";
 
 const ws = createDemo(cloudflareAdapter);
 
@@ -11,8 +11,13 @@ export default {
     env: Record<string, any>,
     context: ExecutionContext,
   ) {
+    const response = handleDemoRoutes(ws, request);
+    if (response) {
+      return response;
+    }
+
     if (request.headers.get("upgrade") === "websocket") {
-      return ws.handleUpgrade(request, env, context);
+      return ws.handleUpgrade(request as any, env, context);
     }
 
     return new Response(await getIndexHTML(), {

--- a/test/fixture/deno.ts
+++ b/test/fixture/deno.ts
@@ -5,15 +5,20 @@ import denoAdapter from "../../src/adapters/deno.ts";
 // @ts-ignore
 import type * as _Deno from "../types/lib.deno.d.ts";
 
-import { createDemo, getIndexHTML } from "./_shared.ts";
+import { createDemo, getIndexHTML, handleDemoRoutes } from "./_shared.ts";
 
 const ws = createDemo(denoAdapter);
 
 const port = Number.parseInt(Deno.env.get("PORT") || "") || 3001;
 
-Deno.serve({ hostname: "localhost", port }, async (req, info) => {
-  if (req.headers.get("upgrade") === "websocket") {
-    return ws.handleUpgrade(req, info);
+Deno.serve({ hostname: "localhost", port }, async (request, info) => {
+  const response = handleDemoRoutes(ws, request);
+  if (response) {
+    return response;
+  }
+
+  if (request.headers.get("upgrade") === "websocket") {
+    return ws.handleUpgrade(request, info);
   }
   return new Response(await getIndexHTML(), {
     headers: { "Content-Type": "text/html" },

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -88,4 +88,26 @@ export function wsTests(
       },
     });
   });
+
+  test("get peers from adapter", async () => {
+    await wsConnect(getURL());
+    await wsConnect(getURL());
+    const response = await fetch(getURL().replace("ws", "http") + "peers");
+    const { peers } = (await response.json()) as any;
+    expect(peers.length).toBe(2);
+  });
+
+  test("get peers from peer", async () => {
+    const ws1 = await wsConnect(getURL(), { skip: 1 });
+    const ws2 = await wsConnect(getURL(), { skip: 1 });
+    if (opts.pubsub !== false) {
+      ws1.skip(); // join message for ws2
+    }
+    await ws1.send("peers");
+    await ws2.send("peers");
+    const { peers: peers1 } = await ws1.next();
+    const { peers: peers2 } = await ws2.next();
+    expect(peers1.length).toBe(2);
+    expect(peers1).toMatchObject(peers2);
+  });
 }


### PR DESCRIPTION
For real-world applications, more than simple pub/sub, access to all peers is often required for cross-communication.

This PR adds this possibility to natively track connected peers in all adapters (except cloudflare-durable which tracks via connected web sockets)

Peers are accessible both via global `ws.peers` and from each peer via `peer.peers` (related to #21, #49)

