### PR TITLE
feat(peer): use secure lazy random uuid

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "play:bun": "bun test/fixture/bun.ts",
     "play:cf": "wrangler dev --port 3001 -c test/fixture/wrangler.toml",
     "play:cf-durable": "wrangler dev --port 3001 -c test/fixture/wrangler-durable.toml",
-    "play:deno": "deno run -A test/fixture/deno.ts",
+    "play:deno": "deno run --unstable-byonm -A test/fixture/deno.ts",
     "play:node": "jiti test/fixture/node.ts",
     "play:sse": "bun test/fixture/sse.ts",
     "play:uws": "jiti test/fixture/uws.ts",
@@ -78,6 +78,9 @@
   },
   "resolutions": {
     "crossws": "workspace:*"
+  },
+  "dependencies": {
+    "uncrypto": "^0.1.3"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240729.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      uncrypto:
+        specifier: ^0.1.3
+        version: 0.1.3
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20240729.0

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from "uncrypto";
+
 // https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
 type ReadyState = 0 | 1 | 2 | 3;
 const ReadyStateMap = {
@@ -16,17 +18,18 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   protected _internal: Internal;
   protected _topics: Set<string>;
 
-  private static _idCounter = 0;
-  private _id: string;
+  private _id?: string;
 
   constructor(internal: Internal) {
-    this._id = ++Peer._idCounter + "";
     this._topics = new Set();
     this._internal = internal;
   }
 
   get id(): string {
-    return this._id.toString();
+    if (!this._id) {
+      this._id = randomUUID();
+    }
+    return this._id;
   }
 
   get addr(): string | undefined {
@@ -66,7 +69,7 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   }
 
   toString() {
-    return `#${this.id}`;
+    return this.id;
   }
 
   [Symbol.for("nodejs.util.inspect.custom")]() {

--- a/test/adapters/deno.test.ts
+++ b/test/adapters/deno.test.ts
@@ -2,5 +2,8 @@ import { describe } from "vitest";
 import { wsTestsExec } from "../_utils";
 
 describe("deno", () => {
-  wsTestsExec("deno run -A ./deno.ts", { resHeaders: false, adapter: "deno" });
+  wsTestsExec("deno run --unstable-byonm -A ./deno.ts", {
+    resHeaders: false,
+    adapter: "deno",
+  });
 });

--- a/test/adapters/sse.test.ts
+++ b/test/adapters/sse.test.ts
@@ -13,7 +13,8 @@ describe("sse", () => {
       });
       await new Promise((resolve) => ev.addEventListener("open", resolve));
       ev.close();
-      expect(messages).toMatchObject(["Welcome to the server #1!"]);
+      expect(messages[0]).toMatch(/Welcome to the server \w+/);
+      expect(messages.length).toBe(1);
     });
   });
 });

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -12,7 +12,7 @@ export function wsTests(
 
   test("connect to websocket", async () => {
     const ws = await wsConnect(getURL());
-    expect(await ws.next()).toBe("Welcome to the server #1!");
+    expect(await ws.next()).toMatch(/Welcome to the server \w+/);
   });
 
   test("send ping", async () => {
@@ -25,7 +25,7 @@ export function wsTests(
     const ws1 = await wsConnect(getURL(), { skip: 1 });
     const ws2 = await wsConnect(getURL(), { skip: 1 });
     if (opts.pubsub !== false) {
-      expect(await ws1.next()).toBe("#4 joined!");
+      expect(await ws1.next()).toMatch(/\w+ joined!/);
     }
     await ws1.send("hello from 1");
     expect(await ws1.next()).toBe("hello from 1");


### PR DESCRIPTION
Peer ids used to be derived from a global counter. This can lead to security issues if relying on id to identify clients and also expose server info.

Using `randomUUID` crypto utility, we lazily assign them random ids.

Uncrypto dep is added since sadly Node.js 18 is still a thing until mid next year it is EOL... (bundle overhead is almost zero for other runtimes)
