### PR TITLE
feat!: overhaul peer and message interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,5 @@ dist
 .wrangler
 
 /adapters
+/websocket
 websocket.d.ts

--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -6,38 +6,42 @@ icon: mynaui:api
 
 > Peer object allows easily interacting with connected clients.
 
-Websocket [hooks](/guide/hooks) accept a peer instance as their first argument. You can use peer object to get information about each connected client or send a message to them.
+When a new client connects to the server, crossws creates a peer instance that allows getting information from clients and sending messages to them.
 
-> [!TIP]
-> You can safely log a peer instance to the console using `console.log` it will be automatically stringified with useful information including the remote address and connection status!
-
-## Properties
-
-### `peer.url`
-
-Request http url during upgrade. You can use it to do actions based on path and search params.
-
-### `peer.headers`
-
-Request http headers during upgrade. Youb can use it to do authentication and access upgrade headers.
-
-### `peer.addr`
-
-The IP address of the client.
+## Instance properties
 
 ### `peer.id`
 
-A unique id assigned to the peer.
+Unique random [uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID) identifier for the message.
 
-### `peer.readyState`
+### `peer.request?`
 
-Client connection status (might be `undefined`)
+Access to the upgrade [request](<(https://developer.mozilla.org/en-US/docs/Web/API/Request)>) info. You can use it to do authentication and access users headers and cookies.
 
-:read-more{to="https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState" title="readyState in MDN"}
+> [!NOTE]
+> This property is compatible with web [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) interface, However interface is emulated for Node.js and sometimes unavailable. Refer to the [compatibility table](#compatibility) for more info.
 
-## Methods
+### `peer.remoteAddress?`
 
-### `peer.send(message, compress)`
+The IP address of the client.
+
+> [!NOTE]
+> Not all adapters provide this. Refer to the [compatibility table](#compatibility) for more info.
+
+### `peer.webSocket`
+
+Direct access to the [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) instance (partial).
+
+> [!NOTE]
+> WebSocket available properties vary across runtimes. Refer to the [compatibility table](#compatibility) for more info.
+
+### `peer.extensions`
+
+Access to upgrade extensions using either native `webSocket.extensions` or `x` from `request.headers`
+
+## Instance methods
+
+### `peer.send(message, { compress? })`
 
 Send a message to the connected client.
 
@@ -79,3 +83,37 @@ To close the connection abruptly, use `peer.terminate()`.
 Abruptly close the connection.
 
 To gracefully close the connection, use `peer.close()`.
+
+## Compatibility
+
+|                             | [Bun][bun] | [Cloudflare][cfw] | [Cloudflare (durable)][cfd] | [Deno][deno] | [Node (ws)][nodews] | [Node (μWebSockets)][nodeuws] | [SSE][sse] |
+| --------------------------- | ---------- | ----------------- | --------------------------- | ------------ | ------------------- | ----------------------------- | ---------- |
+| `send()`                    | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
+| `publish()` / `subscribe()` | ✓          | ⨉                 | ✓ [^4]                      | ✓ [^4]       | ✓ [^4]              | ✓                             | ✓ [^4]     |
+| `close()`                   | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
+| `terminate()`               | ✓          | ✓ [^5]            | ✓                           | ✓            | ✓                   | ✓                             | ✓ [^5]     |
+| `request`                   | ✓          | ✓                 | ✓ [^2]                      | ✓            | ✓ [^1]              | ✓ [^1]                        | ✓          |
+| `webSocket.binaryType`      | ✓ [^3]     | ⨉                 | ⨉                           | ✓            | ✓ [^3]              | ⨉                             | ⨉          |
+| `webSocket.bufferedAmount`  | ⨉          | ⨉                 | ⨉                           | ✓            | ✓                   | ✓                             | ⨉          |
+| `webSocket.extensions`      | ⨉          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ⨉          |
+| `webSocket.protocol`        | ⨉          | ⨉                 | ⨉                           | ⨉            | ✓                   | ✓                             | ⨉          |
+| `webSocket.readyState`      | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
+| `webSocket.url`             | ⨉          | ✓                 | ✓                           | ✓            | ✓                   | ⨉                             | ⨉          |
+
+[bun]: /adapters/bun
+[cfw]: /adapters/cloudflare
+[cfd]: /adapters/cloudflare#durable-objects
+[deno]: /adapters/deno
+[nodews]: /adapters/node
+[nodeuws]: /adapters/node#uwebsockets
+[sse]: adapters/sse
+
+[^1]: using a proxy for [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) compatible interface (`url`, `headers` only) wrapping Node.js requests.
+
+[^2]: `request` is not always available (only in `open` hook).
+
+[^3]: these runtimes support non standard binary types including `nodebuffer` and `uint8array`.
+
+[^4]: pubsub is not natively handled by runtime. crossws tracks peers and sends message to them.
+
+[^5]: `close()` will be used for compatibility.

--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -12,11 +12,11 @@ When a new client connects to the server, crossws creates a peer instance that a
 
 ### `peer.id`
 
-Unique random [uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID) identifier for the message.
+Unique random identifier ([uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID)) for the peer.
 
 ### `peer.request?`
 
-Access to the upgrade [request](<(https://developer.mozilla.org/en-US/docs/Web/API/Request)>) info. You can use it to do authentication and access users headers and cookies.
+Access to the upgrade request info. You can use it to do authentication and access users headers and cookies.
 
 > [!NOTE]
 > This property is compatible with web [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) interface, However interface is emulated for Node.js and sometimes unavailable. Refer to the [compatibility table](#compatibility) for more info.
@@ -28,16 +28,12 @@ The IP address of the client.
 > [!NOTE]
 > Not all adapters provide this. Refer to the [compatibility table](#compatibility) for more info.
 
-### `peer.webSocket`
+### `peer.websocket`
 
-Direct access to the [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) instance (partial).
+Direct access to the [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) instance.
 
 > [!NOTE]
-> WebSocket available properties vary across runtimes. Refer to the [compatibility table](#compatibility) for more info.
-
-### `peer.extensions`
-
-Access to upgrade extensions using either native `webSocket.extensions` or `x` from `request.headers`
+> WebSocket properties vary across runtimes. When accessing `peer.websocket`, a lightweight proxy increases stablity. Refer to the [compatibility table](#compatibility) for more info.
 
 ## Instance methods
 
@@ -89,16 +85,17 @@ To gracefully close the connection, use `peer.close()`.
 |                             | [Bun][bun] | [Cloudflare][cfw] | [Cloudflare (durable)][cfd] | [Deno][deno] | [Node (ws)][nodews] | [Node (μWebSockets)][nodeuws] | [SSE][sse] |
 | --------------------------- | ---------- | ----------------- | --------------------------- | ------------ | ------------------- | ----------------------------- | ---------- |
 | `send()`                    | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
-| `publish()` / `subscribe()` | ✓          | ⨉                 | ✓ [^4]                      | ✓ [^4]       | ✓ [^4]              | ✓                             | ✓ [^4]     |
+| `publish()` / `subscribe()` | ✓          | ⨉                 | ✓ [^1]                      | ✓ [^1]       | ✓ [^1]              | ✓                             | ✓ [^1]     |
 | `close()`                   | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
-| `terminate()`               | ✓          | ✓ [^5]            | ✓                           | ✓            | ✓                   | ✓                             | ✓ [^5]     |
-| `request`                   | ✓          | ✓                 | ✓ [^2]                      | ✓            | ✓ [^1]              | ✓ [^1]                        | ✓          |
-| `webSocket.binaryType`      | ✓ [^3]     | ⨉                 | ⨉                           | ✓            | ✓ [^3]              | ⨉                             | ⨉          |
-| `webSocket.bufferedAmount`  | ⨉          | ⨉                 | ⨉                           | ✓            | ✓                   | ✓                             | ⨉          |
-| `webSocket.extensions`      | ⨉          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ⨉          |
-| `webSocket.protocol`        | ⨉          | ⨉                 | ⨉                           | ⨉            | ✓                   | ✓                             | ⨉          |
-| `webSocket.readyState`      | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
-| `webSocket.url`             | ⨉          | ✓                 | ✓                           | ✓            | ✓                   | ⨉                             | ⨉          |
+| `terminate()`               | ✓          | ✓ [^2]            | ✓                           | ✓            | ✓                   | ✓                             | ✓ [^2]     |
+| `request`                   | ✓          | ✓                 | ✓ [^3]                      | ✓            | ✓ [^3]              | ✓ [^3]                        | ✓          |
+| `remoteAddress`             | ✓          | ⨉                 | ⨉                           | ✓            | ✓                   | ✓                             | ⨉          |
+| `websocket.url`             | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
+| `websocket.extensions`      | ✓ [^4]     | ⨉                 | ⨉                           | ✓ [^4]       | ✓ [^4]              | ✓ [^4]                        | ⨉          |
+| `websocket.protocol`        | ✓ [^5]     | ✓ [^5]            | ✓ [^5]                      | [^5] ✓       | ✓ [^5]              | ✓ [^5]                        | ⨉          |
+| `websocket.readyState`      | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓ [^6]                        | ✓ [^6]     |
+| `websocket.binaryType`      | ✓ [^7]     | ⨉                 | ⨉                           | ✓            | ✓ [^7]              | ✓                             | ⨉          |
+| `websocket.bufferedAmount`  | ⨉          | ⨉                 | ⨉                           | ✓            | ✓                   | ✓                             | ⨉          |
 
 [bun]: /adapters/bun
 [cfw]: /adapters/cloudflare
@@ -108,12 +105,18 @@ To gracefully close the connection, use `peer.close()`.
 [nodeuws]: /adapters/node#uwebsockets
 [sse]: adapters/sse
 
+[^1]: pubsub is not natively handled by runtime. peers are internally tracked.
+
+[^2]: `close()` will be used for compatibility.
+
 [^1]: using a proxy for [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) compatible interface (`url`, `headers` only) wrapping Node.js requests.
 
-[^2]: `request` is not always available (only in `open` hook).
+[^3]: `request` is not always available (only in `open` hook).
 
-[^3]: these runtimes support non standard binary types including `nodebuffer` and `uint8array`.
+[^4]: [`websocket.extensions`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/extensions) is polyfilled using [`sec-websocket-extensions`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism#websocket-specific_headers) request header.
 
-[^4]: pubsub is not natively handled by runtime. crossws tracks peers and sends message to them.
+[^5]: [`websocket.protocol`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/protocol) is polyfilled using [`sec-websocket-protocol`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism#websocket-specific_headers) request header.
 
-[^5]: `close()` will be used for compatibility.
+[^6]: [`websocket.readyState`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState) is polyfilled by tracking open/close events.
+
+[^7]: Some runtimes have non standard values including `"nodebuffer"` and `"uint8array"`. crossws auto converts them for [`message.data`](/guide/message#messagedata).

--- a/docs/1.guide/4.message.md
+++ b/docs/1.guide/4.message.md
@@ -13,7 +13,7 @@ On `message` [hook](/guide/hooks), you receive a message object containing data 
 
 ### `message.id`
 
-Unique random [uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID) identifier for the message.
+Unique random identifier ([uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID)) for the message.
 
 ### `message.event`
 

--- a/docs/1.guide/4.message.md
+++ b/docs/1.guide/4.message.md
@@ -4,21 +4,73 @@ icon: solar:letter-line-duotone
 
 # Message
 
-On `message` [hook](/guide/hooks), you receive a message object containing an incoming message from the client.
+On `message` [hook](/guide/hooks), you receive a message object containing data from the client.
 
-> [!TIP]
-> You can safely log `message` object to the console using `console.log` it will be automatically stringified!
+> [!NOTE]
+> Message object is API-compatible with standard Websocket [`MessageEvent`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/message_event) with convenient superset of utils.
 
-## API
+## Instance properties
 
-### `message.text()`
+### `message.id`
 
-Get stringified text version of the message
+Unique random [uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID) identifier for the message.
+
+### `message.event`
+
+Access to the original [message event](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/message_event) if available.
+
+### `message.peer`
+
+Access to the [peer instance](/guide/peer) that emitted the message.
 
 ### `message.rawData`
 
-Raw message data
+Raw message data (can be of any type).
 
-### `message.isBinary`
+### `message.data`
 
-Indicates if the message is binary (might be `undefined`)
+Message data (value varies based on [`peer.binaryType`](/guide/peer#peerbinarytype)).
+
+## Instance methods
+
+### `message.text()`
+
+Get stringified text version of the message.
+
+If raw data is in any other format, it will be automatically converted or decoded.
+
+### `message.json()`
+
+Get parsed version of the message text with [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
+
+### `message.uint8Array()`
+
+Get data as [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) value.
+
+If raw data is in any other format or string, it will be automatically converted or encoded.
+
+### `message.arrayBuffer()`
+
+Get data as [`ArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or [`SharedArrayBuffer`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) value.
+
+If raw data is in any other format or string, it will be automatically converted or encoded.
+
+### `message.blob()`
+
+Get data as [`Blob`](https://developer.mozilla.org/en-US/docs/Web/API/Blob) value.
+
+If raw data is in any other format or string, it will be automatically converted or encoded.
+
+## Adapter support
+
+|         | [Bun][bun] | [Cloudflare][cfw] | [Cloudflare (durable)][cfd] | [Deno][deno] | [Node (ws)][nodews] | [Node (μWebSockets)][nodeuws] | [SSE][sse] |
+| ------- | ---------- | ----------------- | --------------------------- | ------------ | ------------------- | ----------------------------- | ---------- |
+| `event` | ⨉          | ✓                 | ⨉                           | ✓            | ⨉                   | ⨉                             | ⨉          |
+
+[bun]: /adapters/bun
+[cfw]: /adapters/cloudflare
+[cfd]: /adapters/cloudflare#durable-objects
+[deno]: /adapters/deno
+[nodews]: /adapters/node
+[nodeuws]: /adapters/node#uwebsockets
+[sse]: adapters/sse

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -1,5 +1,4 @@
 import type { AdapterOptions, AdapterInstance } from "../adapter.ts";
-import type { WebSocket } from "../../types/web.ts";
 import { toBufferLike } from "../utils.ts";
 import { defineWebSocketAdapter, adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -101,6 +101,6 @@ class DenoPeer extends Peer<{
   }
 
   terminate(): void {
-    this._internal.ws.terminate();
+    (this._internal.ws as any).terminate();
   }
 }

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -142,11 +142,6 @@ class NodePeer extends Peer<{
     return this._internal.nodeReq.socket?.remoteAddress;
   }
 
-  constructor(ctx: NodePeer["_internal"]) {
-    super(ctx);
-    ctx.ws._peer = this;
-  }
-
   send(data: unknown, options?: { compress?: boolean }) {
     const dataBuff = toBufferLike(data);
     const isBinary = typeof data !== "string";

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,4 +1,5 @@
 import type { AdapterOptions, AdapterInstance } from "../adapter.ts";
+import type { WebSocket } from "../../types/web.ts";
 import { toBufferLike } from "../utils.ts";
 import { defineWebSocketAdapter, adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
@@ -11,14 +12,16 @@ import type { Duplex } from "node:stream";
 import { WebSocketServer as _WebSocketServer } from "ws";
 import type {
   ServerOptions,
-  RawData,
   WebSocketServer,
   WebSocket as WebSocketT,
 } from "../../types/ws";
 
 // --- types ---
 
-type AugmentedReq = IncomingMessage & { _upgradeHeaders?: HeadersInit };
+type AugmentedReq = IncomingMessage & {
+  _request: NodeReqProxy;
+  _upgradeHeaders?: HeadersInit;
+};
 
 export interface NodeAdapter extends AdapterInstance {
   handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): void;
@@ -46,18 +49,19 @@ export default defineWebSocketAdapter<NodeAdapter, NodeOptions>(
         ...(options.serverOptions as any),
       }) as WebSocketServer);
 
-    wss.on("connection", (ws, req) => {
-      const peer = new NodePeer({ peers, node: { ws, req, server: wss } });
+    wss.on("connection", (ws, nodeReq) => {
+      const request = new NodeReqProxy(nodeReq);
+      const peer = new NodePeer({ ws, request, peers, nodeReq });
       peers.add(peer);
       hooks.callHook("open", peer);
 
       // Managed socket-level events
-      ws.on("message", (data: RawData, isBinary: boolean) => {
+      ws.on("message", (data: unknown, isBinary: boolean) => {
         hooks.callAdapterHook("node:message", peer, data, isBinary);
         if (Array.isArray(data)) {
           data = Buffer.concat(data);
         }
-        hooks.callHook("message", peer, new Message(data, isBinary));
+        hooks.callHook("message", peer, new Message(data, peer));
       });
       ws.on("error", (error: Error) => {
         peers.delete(peer);
@@ -94,7 +98,7 @@ export default defineWebSocketAdapter<NodeAdapter, NodeOptions>(
       });
     });
 
-    wss.on("headers", function (outgoingHeaders, req) {
+    wss.on("headers", (outgoingHeaders, req) => {
       const upgradeHeaders = (req as AugmentedReq)._upgradeHeaders;
       if (upgradeHeaders) {
         for (const [key, value] of new Headers(upgradeHeaders)) {
@@ -105,14 +109,16 @@ export default defineWebSocketAdapter<NodeAdapter, NodeOptions>(
 
     return {
       ...adapterUtils(peers),
-      handleUpgrade: async (req, socket, head) => {
-        const res = await hooks.callHook("upgrade", new NodeReqProxy(req));
+      handleUpgrade: async (nodeReq, socket, head) => {
+        const request = new NodeReqProxy(nodeReq);
+        const res = await hooks.callHook("upgrade", request);
         if (res instanceof Response) {
           return sendResponse(socket, res);
         }
-        (req as AugmentedReq)._upgradeHeaders = res?.headers;
-        wss.handleUpgrade(req, socket, head, (ws) => {
-          wss.emit("connection", ws, req);
+        (nodeReq as AugmentedReq)._request = request;
+        (nodeReq as AugmentedReq)._upgradeHeaders = res?.headers;
+        wss.handleUpgrade(nodeReq, socket, head, (ws) => {
+          wss.emit("connection", ws, nodeReq);
         });
       },
       closeAll: (code, data) => {
@@ -128,49 +134,23 @@ export default defineWebSocketAdapter<NodeAdapter, NodeOptions>(
 
 class NodePeer extends Peer<{
   peers: Set<NodePeer>;
-  node: {
-    server: WebSocketServer;
-    req: IncomingMessage;
-    ws: WebSocketT & { _peer?: NodePeer };
-  };
+  request: NodeReqProxy;
+  nodeReq: IncomingMessage;
+  ws: WebSocketT & { _peer?: NodePeer };
 }> {
-  _req: NodeReqProxy;
+  get remoteAddress() {
+    return this._internal.nodeReq.socket?.remoteAddress;
+  }
+
   constructor(ctx: NodePeer["_internal"]) {
     super(ctx);
-    this._req = new NodeReqProxy(ctx.node.req);
-    ctx.node.ws._peer = this;
+    ctx.ws._peer = this;
   }
 
-  get addr() {
-    const socket = this._internal.node.req.socket;
-    if (!socket) {
-      return undefined;
-    }
-    const headers = this._internal.node.req.headers;
-    let addr = headers["x-forwarded-for"] || socket.remoteAddress || "??";
-    if (addr.includes(":")) {
-      addr = `[${addr}]`;
-    }
-    const port = headers["x-forwarded-port"] || socket.remotePort || "??";
-    return `${addr}:${port}`;
-  }
-
-  get url() {
-    return this._req.url;
-  }
-
-  get headers() {
-    return this._req.headers;
-  }
-
-  get readyState() {
-    return this._internal.node.ws.readyState;
-  }
-
-  send(message: any, options?: { compress?: boolean }) {
-    const data = toBufferLike(message);
+  send(data: unknown, options?: { compress?: boolean }) {
+    const dataBuff = toBufferLike(data);
     const isBinary = typeof data !== "string";
-    this._internal.node.ws.send(data, {
+    this._internal.ws.send(dataBuff, {
       compress: options?.compress,
       binary: isBinary,
       ...options,
@@ -178,8 +158,12 @@ class NodePeer extends Peer<{
     return 0;
   }
 
-  publish(topic: string, message: any, options?: { compress?: boolean }): void {
-    const data = toBufferLike(message);
+  publish(
+    topic: string,
+    data: unknown,
+    options?: { compress?: boolean },
+  ): void {
+    const dataBuff = toBufferLike(data);
     const isBinary = typeof data !== "string";
     const sendOptions = {
       compress: options?.compress,
@@ -188,17 +172,17 @@ class NodePeer extends Peer<{
     };
     for (const peer of this._internal.peers) {
       if (peer !== this && peer._topics.has(topic)) {
-        peer._internal.node.ws.send(data, sendOptions);
+        peer._internal.ws.send(dataBuff, sendOptions);
       }
     }
   }
 
   close(code?: number, data?: string | Buffer) {
-    this._internal.node.ws.close(code, data);
+    this._internal.ws.close(code, data);
   }
 
   terminate() {
-    this._internal.node.ws.terminate();
+    this._internal.ws.terminate();
   }
 }
 

--- a/src/adapters/sse.ts
+++ b/src/adapters/sse.ts
@@ -100,22 +100,22 @@ class SSEPeer extends Peer<{
   _sseStream: ReadableStream; // server -> client
   _sseStreamController?: ReadableStreamDefaultController;
 
-  constructor(internal: SSEPeer["_internal"]) {
-    super(internal);
-    this._internal.ws.readyState = 0 /* CONNECTING */;
+  constructor(_internal: SSEPeer["_internal"]) {
+    super(_internal);
+    _internal.ws.readyState = 0 /* CONNECTING */;
     this._sseStream = new ReadableStream({
       start: (controller) => {
-        this._internal.ws.readyState = 1 /* OPEN */;
+        _internal.ws.readyState = 1 /* OPEN */;
         this._sseStreamController = controller;
-        this._internal.hooks.callHook("open", this);
+        _internal.hooks.callHook("open", this);
       },
       cancel: () => {
-        this._internal.ws.readyState = 2 /* CLOSING */;
-        this._internal.peers.delete(this);
-        this._internal.peersMap?.delete(this.id);
+        _internal.ws.readyState = 2 /* CLOSING */;
+        _internal.peers.delete(this);
+        _internal.peersMap?.delete(this.id);
         Promise.resolve(this._internal.hooks.callHook("close", this)).finally(
           () => {
-            this._internal.ws.readyState = 3 /* CLOSED */;
+            _internal.ws.readyState = 3 /* CLOSED */;
           },
         );
       },

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -51,14 +51,16 @@ export default defineWebSocketAdapter<UWSAdapter, UWSOptions>(
         ...options.uws,
         close(ws, code, message) {
           const peer = getPeer(ws, peers);
-          (peer.webSocket as UwsWebSocketProxy).readyState = 2 /* CLOSING */;
+          ((peer as any)._internal.ws as UwsWebSocketProxy).readyState =
+            2 /* CLOSING */;
           peers.delete(peer);
           hooks.callAdapterHook("uws:close", peer, ws, code, message);
           hooks.callHook("close", peer, {
             code,
             reason: message?.toString(),
           });
-          (peer.webSocket as UwsWebSocketProxy).readyState = 3 /* CLOSED */;
+          ((peer as any)._internal.ws as UwsWebSocketProxy).readyState =
+            3 /* CLOSED */;
         },
         drain(ws) {
           const peer = getPeer(ws, peers);
@@ -181,7 +183,7 @@ class UWSPeer extends Peer<{
       const addr = new TextDecoder().decode(
         this._internal.uws.getRemoteAddressAsText(),
       );
-      return addr.replace(/(0000:)+/, "");
+      return addr;
     } catch {
       // Error: Invalid access of closed uWS.WebSocket/SSLWebSocket.
     }

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -1,28 +1,23 @@
 import type { AdapterOptions, AdapterInstance } from "../adapter.ts";
+import type { WebSocket } from "../../types/web.ts";
+import type uws from "uWebSockets.js";
 import { toBufferLike } from "../utils.ts";
 import { defineWebSocketAdapter, adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { Peer } from "../peer.ts";
 
-import type {
-  WebSocketBehavior,
-  WebSocket,
-  HttpRequest,
-  HttpResponse,
-  RecognizedString,
-} from "uWebSockets.js";
-
 // --- types ---
 
 type UserData = {
-  _peer?: any;
-  req: HttpRequest;
-  res: HttpResponse;
-  context: any;
+  peer?: UWSPeer;
+  req: uws.HttpRequest;
+  res: uws.HttpResponse;
+  protocol: string;
+  extensions: string;
 };
 
-type WebSocketHandler = WebSocketBehavior<UserData>;
+type WebSocketHandler = uws.WebSocketBehavior<UserData>;
 
 export interface UWSAdapter extends AdapterInstance {
   websocket: WebSocketHandler;
@@ -30,7 +25,7 @@ export interface UWSAdapter extends AdapterInstance {
 
 export interface UWSOptions extends AdapterOptions {
   uws?: Exclude<
-    WebSocketBehavior<any>,
+    uws.WebSocketBehavior<any>,
     | "close"
     | "drain"
     | "message"
@@ -56,12 +51,14 @@ export default defineWebSocketAdapter<UWSAdapter, UWSOptions>(
         ...options.uws,
         close(ws, code, message) {
           const peer = getPeer(ws, peers);
+          (peer.webSocket as UwsWebSocketProxy).readyState = 2 /* CLOSING */;
           peers.delete(peer);
           hooks.callAdapterHook("uws:close", peer, ws, code, message);
           hooks.callHook("close", peer, {
             code,
             reason: message?.toString(),
           });
+          (peer.webSocket as UwsWebSocketProxy).readyState = 3 /* CLOSED */;
         },
         drain(ws) {
           const peer = getPeer(ws, peers);
@@ -70,8 +67,7 @@ export default defineWebSocketAdapter<UWSAdapter, UWSOptions>(
         message(ws, message, isBinary) {
           const peer = getPeer(ws, peers);
           hooks.callAdapterHook("uws:message", peer, ws, message, isBinary);
-          const msg = new Message(message, isBinary);
-          hooks.callHook("message", peer, msg);
+          hooks.callHook("message", peer, new Message(message, peer));
         },
         open(ws) {
           const peer = getPeer(ws, peers);
@@ -131,16 +127,21 @@ export default defineWebSocketAdapter<UWSAdapter, UWSOptions>(
               res.writeHeader(key, value);
             }
           }
+
           res.cork(() => {
+            const key = req.getHeader("sec-websocket-key");
+            const protocol = req.getHeader("sec-websocket-protocol");
+            const extensions = req.getHeader("sec-websocket-extensions");
             res.upgrade(
               {
                 req,
                 res,
-                context,
+                protocol,
+                extensions,
               },
-              req.getHeader("sec-websocket-key"),
-              req.getHeader("sec-websocket-protocol"),
-              req.getHeader("sec-websocket-extensions"),
+              key,
+              protocol,
+              extensions,
               context,
             );
           });
@@ -152,35 +153,33 @@ export default defineWebSocketAdapter<UWSAdapter, UWSOptions>(
 
 // --- peer ---
 
-function getPeer(ws: WebSocket<UserData>, peers: Set<UWSPeer>): UWSPeer {
-  const userData = ws.getUserData();
-  if (userData._peer) {
-    return userData._peer as UWSPeer;
+function getPeer(uws: uws.WebSocket<UserData>, peers: Set<UWSPeer>): UWSPeer {
+  const uwsData = uws.getUserData();
+  if (uwsData.peer) {
+    return uwsData.peer;
   }
-  const peer = new UWSPeer({ peers, uws: { ws, userData } });
-  userData._peer = peer;
+  const peer = new UWSPeer({
+    peers,
+    uws,
+    ws: new UwsWebSocketProxy(uws),
+    request: new UWSReqProxy(uwsData.req),
+    uwsData,
+  });
+  uwsData.peer = peer;
   return peer;
 }
 
 class UWSPeer extends Peer<{
   peers: Set<UWSPeer>;
-  uws: {
-    ws: WebSocket<UserData>;
-    userData: UserData;
-  };
+  request: UWSReqProxy;
+  uws: uws.WebSocket<UserData>;
+  ws: UwsWebSocketProxy;
+  uwsData: UserData;
 }> {
-  _decoder = new TextDecoder();
-  _req: UWSReqProxy;
-
-  constructor(ctx: UWSPeer["_internal"]) {
-    super(ctx);
-    this._req = new UWSReqProxy(ctx.uws.userData.req);
-  }
-
-  get addr() {
+  get remoteAddress() {
     try {
-      const addr = this._decoder.decode(
-        this._internal.uws.ws?.getRemoteAddressAsText(),
+      const addr = new TextDecoder().decode(
+        this._internal.uws.getRemoteAddressAsText(),
       );
       return addr.replace(/(0000:)+/, "");
     } catch {
@@ -188,37 +187,29 @@ class UWSPeer extends Peer<{
     }
   }
 
-  get url() {
-    return this._req.url;
-  }
-
-  get headers() {
-    return this._req.headers;
-  }
-
-  send(message: any, options?: { compress?: boolean }) {
-    const data = toBufferLike(message);
+  send(data: unknown, options?: { compress?: boolean }) {
+    const dataBuff = toBufferLike(data);
     const isBinary = typeof data !== "string";
-    return this._internal.uws.ws.send(data, isBinary, options?.compress);
+    return this._internal.uws.send(dataBuff, isBinary, options?.compress);
   }
 
   subscribe(topic: string): void {
-    this._internal.uws.ws.subscribe(topic);
+    this._internal.uws.subscribe(topic);
   }
 
   publish(topic: string, message: string, options?: { compress?: boolean }) {
     const data = toBufferLike(message);
     const isBinary = typeof data !== "string";
-    this._internal.uws.ws.publish(topic, data, isBinary, options?.compress);
+    this._internal.uws.publish(topic, data, isBinary, options?.compress);
     return 0;
   }
 
-  close(code?: number, reason?: RecognizedString) {
-    this._internal.uws.ws.end(code, reason);
+  close(code?: number, reason?: uws.RecognizedString) {
+    this._internal.uws.end(code, reason);
   }
 
   terminate(): void {
-    this._internal.uws.ws.close();
+    this._internal.uws.close();
   }
 }
 
@@ -227,11 +218,10 @@ class UWSPeer extends Peer<{
 class UWSReqProxy {
   private _headers?: Headers;
   private _rawHeaders: [string, string][] = [];
+
   url: string;
 
-  constructor(_req: HttpRequest) {
-    // We need to precompute values since uws doesn't provide them after handler.
-
+  constructor(_req: uws.HttpRequest) {
     // Headers
     let host = "localhost";
     let proto = "http";
@@ -244,7 +234,6 @@ class UWSReqProxy {
       }
       this._rawHeaders.push([key, value]);
     });
-
     // URL
     const query = _req.getQuery();
     const pathname = _req.getUrl();
@@ -256,5 +245,23 @@ class UWSReqProxy {
       this._headers = new Headers(this._rawHeaders);
     }
     return this._headers;
+  }
+}
+
+class UwsWebSocketProxy implements Partial<WebSocket> {
+  readyState?: number = 1 /* OPEN */;
+
+  constructor(private _uws: uws.WebSocket<UserData>) {}
+
+  get bufferedAmount() {
+    return this._uws?.getBufferedAmount();
+  }
+
+  get protocol() {
+    return this._uws?.getUserData().protocol;
+  }
+
+  get extensions() {
+    return this._uws?.getUserData().extensions;
   }
 }

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,27 +1,202 @@
-import { toBufferLike } from "./utils.ts";
+import type { Peer } from "./peer.ts";
+import { randomUUID } from "uncrypto";
 
-export class Message {
-  constructor(
-    public readonly rawData: any,
-    public readonly isBinary?: boolean,
-  ) {}
+export class Message implements Partial<MessageEvent> {
+  /** Access to the original [message event](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/message_event) if available. */
+  readonly event?: MessageEvent;
 
-  text(): string {
-    if (typeof this.rawData === "string") {
-      return this.rawData;
-    }
-    const buff = toBufferLike(this.rawData);
-    if (typeof buff === "string") {
-      return buff;
-    }
-    return new TextDecoder().decode(buff);
+  /** Access to the Peer that emitted the message. */
+  readonly peer?: Peer;
+
+  /** Raw message data (can be of any type). */
+  readonly rawData: unknown;
+
+  #id?: string;
+  #uint8Array?: Uint8Array;
+  #arrayBuffer?: ArrayBuffer | SharedArrayBuffer;
+  #blob?: Blob;
+  #text?: string;
+  #json?: unknown;
+
+  constructor(rawData: unknown, peer: Peer, event?: MessageEvent) {
+    this.rawData = rawData || "";
+    this.peer = peer;
+    this.event = event;
   }
+
+  /**
+   * Unique random [uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID) identifier for the message.
+   */
+  get id(): string {
+    if (!this.#id) {
+      this.#id = randomUUID();
+    }
+    return this.#id;
+  }
+
+  // --- data views ---
+
+  /**
+   * Get data as [Uint8Array](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) value.
+   *
+   * If raw data is in any other format or string, it will be automatically converted and encoded.
+   */
+  uint8Array() {
+    // Cached
+    const _uint8Array = this.#uint8Array;
+    if (_uint8Array) {
+      return _uint8Array;
+    }
+    const rawData = this.rawData;
+    // Uint8Array
+    if (rawData instanceof Uint8Array) {
+      return (this.#uint8Array = rawData);
+    }
+    // ArrayBuffer
+    if (
+      rawData instanceof ArrayBuffer ||
+      rawData instanceof SharedArrayBuffer
+    ) {
+      this.#arrayBuffer = rawData;
+      return (this.#uint8Array = new Uint8Array(rawData));
+    }
+    // String
+    if (typeof rawData === "string") {
+      this.#text = rawData;
+      return (this.#uint8Array = new TextEncoder().encode(this.#text));
+    }
+    // Iterable and ArrayLike
+    if (Symbol.iterator in (rawData as Iterable<number>)) {
+      return (this.#uint8Array = new Uint8Array(rawData as Iterable<number>));
+    }
+    if (typeof (rawData as ArrayLike<number>)?.length === "number") {
+      return (this.#uint8Array = new Uint8Array(rawData as ArrayLike<number>));
+    }
+    // DataView
+    if (rawData instanceof DataView) {
+      return (this.#uint8Array = new Uint8Array(
+        rawData.buffer,
+        rawData.byteOffset,
+        rawData.byteLength,
+      ));
+    }
+    throw new TypeError(
+      `Unsupported message type: ${Object.prototype.toString.call(rawData)}`,
+    );
+  }
+
+  /**
+   * Get data as [ArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/ArrayBuffer) or [SharedArrayBuffer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SharedArrayBuffer) value.
+   *
+   * If raw data is in any other format or string, it will be automatically converted and encoded.
+   */
+  arrayBuffer(): ArrayBuffer | SharedArrayBuffer {
+    // Cached
+    const _arrayBuffer = this.#arrayBuffer;
+    if (_arrayBuffer) {
+      return _arrayBuffer;
+    }
+    const rawData = this.rawData;
+    // Use as-is
+    if (
+      rawData instanceof ArrayBuffer ||
+      rawData instanceof SharedArrayBuffer
+    ) {
+      return (this.#arrayBuffer = rawData);
+    }
+    // Fallback to UInt8Array
+    return (this.#arrayBuffer = this.uint8Array().buffer);
+  }
+
+  /**
+   * Get data as [Blob](https://developer.mozilla.org/en-US/docs/Web/API/Blob) value.
+   *
+   * If raw data is in any other format or string, it will be automatically converted and encoded. */
+  blob(): Blob {
+    // Cached
+    const _blob = this.#blob;
+    if (_blob) {
+      return _blob;
+    }
+    const rawData = this.rawData;
+    // Use as-is
+    if (rawData instanceof Blob) {
+      return (this.#blob = rawData);
+    }
+    // Fallback to UInt8Array
+    return (this.#blob = new Blob([this.uint8Array()]));
+  }
+
+  /**
+   * Get stringified text version of the message.
+   *
+   * If raw data is in any other format, it will be automatically converted and decoded.
+   */
+  text(): string {
+    // Cached
+    const _text = this.#text;
+    if (_text) {
+      return _text;
+    }
+    const rawData = this.rawData;
+    // Use as-is
+    if (typeof rawData === "string") {
+      return (this.#text = rawData);
+    }
+    // Fallback to UInt8Array
+    return (this.#text = new TextDecoder().decode(this.uint8Array()));
+  }
+
+  /**
+   * Get parsed version of the message text with [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
+   */
+  json<T = unknown>(): T {
+    const _json = this.#json;
+    if (_json) {
+      return _json as T;
+    }
+    return (this.#json = JSON.parse(this.text()));
+  }
+
+  /**
+   * Message data (value varies based on `peer.websocket.binaryType`).
+   */
+  get data() {
+    switch (this.peer?.webSocket?.binaryType as string) {
+      case "arraybuffer": {
+        return this.arrayBuffer();
+      }
+      case "blob": {
+        return this.blob();
+      }
+      case "nodebuffer": {
+        return globalThis.Buffer
+          ? Buffer.from(this.uint8Array())
+          : this.uint8Array();
+      }
+      case "uint8array": {
+        return this.uint8Array();
+      }
+      case "text": {
+        return this.text();
+      }
+      default: {
+        return this.rawData;
+      }
+    }
+  }
+
+  // --- inspect ---
 
   toString() {
     return this.text();
   }
 
-  [Symbol.for("nodejs.util.inspect.custom")]() {
+  [Symbol.toPrimitive]() {
     return this.text();
+  }
+
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+    return { data: this.rawData };
   }
 }

--- a/src/message.ts
+++ b/src/message.ts
@@ -162,7 +162,7 @@ export class Message implements Partial<MessageEvent> {
    * Message data (value varies based on `peer.websocket.binaryType`).
    */
   get data() {
-    switch (this.peer?.webSocket?.binaryType as string) {
+    switch (this.peer?.websocket?.binaryType as string) {
       case "arraybuffer": {
         return this.arrayBuffer();
       }

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -1,111 +1,119 @@
 import { randomUUID } from "uncrypto";
 
-// https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState
-type ReadyState = 0 | 1 | 2 | 3;
-const ReadyStateMap = {
-  "-1": "unknown",
-  0: "connecting",
-  1: "open",
-  2: "closing",
-  3: "closed",
-} as const;
-
 export interface AdapterInternal {
+  ws: unknown;
+  request?: Request | Partial<Request>;
   peers?: Set<Peer>;
 }
 
 export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   protected _internal: Internal;
   protected _topics: Set<string>;
-
-  private _id?: string;
+  #id?: string;
 
   constructor(internal: Internal) {
     this._topics = new Set();
     this._internal = internal;
   }
 
+  /**
+   * Unique random [uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID) identifier for the peer.
+   */
   get id(): string {
-    if (!this._id) {
-      this._id = randomUUID();
+    if (!this.#id) {
+      this.#id = randomUUID();
     }
-    return this._id;
+    return this.#id;
   }
 
-  get addr(): string | undefined {
+  /** IP address of the peer */
+  get remoteAddress(): string | undefined {
     return undefined;
   }
 
-  get url(): string {
-    return "";
+  /** upgrade request */
+  get request(): Request | Partial<Request> | undefined {
+    return this._internal.request;
   }
 
-  get headers(): Headers | undefined {
-    return undefined;
-  }
-
-  get readyState(): ReadyState | -1 {
-    return -1;
-  }
-
+  /** All connected peers to the server */
   get peers(): Set<Peer> {
     return this._internal.peers || new Set();
   }
 
-  abstract send(message: any, options?: { compress?: boolean }): number;
+  /** Get the [WebSocket](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) instance. */
+  get webSocket(): WebSocket | Partial<WebSocket> {
+    return this._internal.ws as WebSocket | Partial<WebSocket>;
+  }
 
-  abstract publish(
-    topic: string,
-    message: any,
-    options?: { compress?: boolean },
-  ): void;
+  get protocol(): string | undefined {
+    return (
+      this.webSocket.protocol ||
+      this.request?.headers?.get("sec-websocket-protocol") ||
+      undefined
+    );
+  }
 
+  get extensions(): string | undefined {
+    return (
+      this.webSocket.extensions ||
+      this.request?.headers?.get("sec-websocket-extensions") ||
+      undefined
+    );
+  }
+
+  abstract close(code?: number, reason?: string): void;
+
+  /** Abruptly close the connection */
+  terminate() {
+    this.close();
+  }
+
+  /** Subscribe to a topic */
   subscribe(topic: string) {
     this._topics.add(topic);
   }
 
+  /** Unsubscribe from a topic */
   unsubscribe(topic: string) {
     this._topics.delete(topic);
   }
+
+  /** Send a message to the peer. */
+  abstract send(
+    data: unknown,
+    options?: { compress?: boolean },
+  ): number | void | undefined;
+
+  /** Send message to subscribes of topic */
+  abstract publish(
+    topic: string,
+    data: unknown,
+    options?: { compress?: boolean },
+  ): void;
+
+  // --- inspect ---
 
   toString() {
     return this.id;
   }
 
-  [Symbol.for("nodejs.util.inspect.custom")]() {
-    const _id = this.toString();
-    const _addr = this.addr ? ` (${this.addr})` : "";
-    const _state =
-      this.readyState === 1 || this.readyState === -1
-        ? ""
-        : ` [${ReadyStateMap[this.readyState]}]`;
-
-    return `${_id}${_addr}${_state}`;
+  [Symbol.toPrimitive]() {
+    return this.id;
   }
 
-  /**
-   * Closes the connection.
-   *
-   * Here is a list of close codes:
-   *
-   * - `1000` means "normal closure" (default)
-   * - `1009` means a message was too big and was rejected
-   * - `1011` means the server encountered an error
-   * - `1012` means the server is restarting
-   * - `1013` means the server is too busy or the client is rate-limited
-   * - `4000` through `4999` are reserved for applications (you can use it!)
-   *
-   * To close the connection abruptly, use `terminate()`.
-   *
-   * @param code The close code to send
-   * @param reason The close reason to send
-   */
-  abstract close(code?: number, reason?: string): void;
+  [Symbol.toStringTag]() {
+    return "WebSocket";
+  }
 
-  /**
-   * Abruptly close the connection.
-   *
-   * To gracefully close the connection, use `close()`.
-   */
-  abstract terminate(): void;
+  [Symbol.for("nodejs.util.inspect.custom")]() {
+    return Object.fromEntries(
+      [
+        ["id", this.id],
+        ["remoteAddress", this.remoteAddress],
+        ["peers", this.peers],
+        ["webSocket", this.webSocket],
+      ].filter((p) => p[1]),
+    );
+  }
 }

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -27,9 +27,19 @@ export function createDemo<T extends Adapter<any, any>>(
         case "debug": {
           peer.send({
             id: peer.id,
-            ip: peer.addr,
-            url: peer.url,
-            headers: Object.fromEntries(peer.headers || []),
+            ip: peer.remoteAddress,
+            protocol: peer.protocol,
+            extensions: peer.extensions,
+            request: {
+              url: peer.request?.url,
+              headers: Object.fromEntries(peer.request?.headers || []),
+            },
+            webSocket: {
+              readyState: peer.webSocket.readyState,
+              protocol: peer.webSocket.protocol,
+              extensions: peer.webSocket.extensions,
+              url: peer.webSocket.url,
+            },
           });
           break;
         }

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -27,18 +27,18 @@ export function createDemo<T extends Adapter<any, any>>(
         case "debug": {
           peer.send({
             id: peer.id,
-            ip: peer.remoteAddress,
-            protocol: peer.protocol,
-            extensions: peer.extensions,
+            remoteAddress: peer.remoteAddress,
             request: {
               url: peer.request?.url,
               headers: Object.fromEntries(peer.request?.headers || []),
             },
-            webSocket: {
-              readyState: peer.webSocket.readyState,
-              protocol: peer.webSocket.protocol,
-              extensions: peer.webSocket.extensions,
-              url: peer.webSocket.url,
+            websocket: {
+              readyState: peer.websocket.readyState,
+              protocol: peer.websocket.protocol,
+              extensions: peer.websocket.extensions,
+              url: peer.websocket.url,
+              binaryType: peer.websocket.binaryType,
+              bufferedAmount: peer.websocket.bufferedAmount,
             },
           });
           break;

--- a/test/fixture/deno.ts
+++ b/test/fixture/deno.ts
@@ -1,4 +1,4 @@
-// You can run this demo using `deno run -A ./deno.ts` or  `npm run play:deno` in repo
+// You can run this demo using `npm run play:deno` in repo
 
 import denoAdapter from "../../src/adapters/deno.ts";
 

--- a/types/web.ts
+++ b/types/web.ts
@@ -255,7 +255,7 @@ export interface WebSocket extends EventTarget {
    *
    * [MDN Reference](https://developer.mozilla.org/docs/Web/API/WebSocket/binaryType)
    */
-  binaryType: BinaryType;
+  binaryType: BinaryType | (string & {});
   /**
    * Returns the number of bytes of application data (UTF-8 text and binary data) that have been queued using send() but not yet been transmitted to the network.
    *

--- a/websocket/sse.d.ts
+++ b/websocket/sse.d.ts
@@ -1,2 +1,0 @@
-export * from "../dist/websocket/sse";
-export { default } from "../dist/websocket/sse";

--- a/websocket/sse.d.ts
+++ b/websocket/sse.d.ts
@@ -1,0 +1,2 @@
+export * from "../dist/websocket/sse";
+export { default } from "../dist/websocket/sse";


### PR DESCRIPTION
overhaul `Peer` and `Message` objects to be forward compatible and more compatible with web standards. 

(refer to the updated docs)

Message:

- New `message.id`
- New `message.event`
- New `message.peer`
- New `message.data`
- New `message.json()`
- New `message.arrayBuffer()`
- New `message.uint8Array()`
- New `message.blob()`
- Removed `message.isBinary (use new runtime safe methods)

Peer:

- Renamed `peer.addr` to `peer.remoteAddress`
- You can access upgrade request with standard `peer.request`
   - Moved `peer.url` / `peer.headers` to `peer.request.url` / `peer.request.headers`
- You can access peer websocket with standard `peer.webSocket`
   - Moved `peer.readyState` to  `peer.webSocket.readyState`
   - Compatibility added for `url`, `extensions`, `protocol` and `readyState`
