### PR TITLE
fix(cloudflare-durable): restore peer url and id after hibernation

### DIFF
--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -88,7 +88,7 @@ To gracefully close the connection, use `peer.close()`.
 | `publish()` / `subscribe()` | ✓          | ⨉                 | ✓ [^1]                      | ✓ [^1]       | ✓ [^1]              | ✓                             | ✓ [^1]     |
 | `close()`                   | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
 | `terminate()`               | ✓          | ✓ [^2]            | ✓                           | ✓            | ✓                   | ✓                             | ✓ [^2]     |
-| `request`                   | ✓          | ✓                 | ✓ [^3]                      | ✓            | ✓ [^3]              | ✓ [^3]                        | ✓          |
+| `request`                   | ✓          | ✓                 | ✓ [^30]                     | ✓            | ✓ [^31]             | ✓ [^31]                       | ✓          |
 | `remoteAddress`             | ✓          | ⨉                 | ⨉                           | ✓            | ✓                   | ✓                             | ⨉          |
 | `websocket.url`             | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
 | `websocket.extensions`      | ✓ [^4]     | ⨉                 | ⨉                           | ✓ [^4]       | ✓ [^4]              | ✓ [^4]                        | ⨉          |
@@ -109,9 +109,9 @@ To gracefully close the connection, use `peer.close()`.
 
 [^2]: `close()` will be used for compatibility.
 
-[^1]: using a proxy for [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) compatible interface (`url`, `headers` only) wrapping Node.js requests.
+[^30]: After durable object's hibernation, only `request.url` (and `peer.id`) remain available due to 2048 byte in-memory state limit.
 
-[^3]: `request` is not always available (only in `open` hook).
+[^31]: using a proxy for [Request](https://developer.mozilla.org/en-US/docs/Web/API/Request) compatible interface (`url`, `headers` only) wrapping Node.js requests.
 
 [^4]: [`websocket.extensions`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/extensions) is polyfilled using [`sec-websocket-extensions`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Protocol_upgrade_mechanism#websocket-specific_headers) request header.
 

--- a/docs/2.adapters/cloudflare.md
+++ b/docs/2.adapters/cloudflare.md
@@ -77,6 +77,11 @@ export default {
 };
 
 export class $DurableObject extends DurableObject {
+  constructor(state, env) {
+    super(state, env);
+    ws.handleDurableInit(this, state, env);
+  }
+
   fetch(request) {
     return ws.handleDurableUpgrade(this, request);
   }

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -10,7 +10,8 @@ export interface AdapterInternal {
 export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   protected _internal: Internal;
   protected _topics: Set<string>;
-  #id?: string;
+  protected _id?: string;
+
   #ws?: Partial<web.WebSocket>;
 
   constructor(internal: Internal) {
@@ -22,10 +23,10 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
    * Unique random [uuid v4](https://developer.mozilla.org/en-US/docs/Glossary/UUID) identifier for the peer.
    */
   get id(): string {
-    if (!this.#id) {
-      this.#id = randomUUID();
+    if (!this._id) {
+      this._id = randomUUID();
     }
-    return this.#id;
+    return this._id;
   }
 
   /** IP address of the peer */

--- a/test/fixture/_index.html.ts
+++ b/test/fixture/_index.html.ts
@@ -77,12 +77,9 @@ export default function indexTemplate(opts: { sse?: boolean } = {}) {
           ws = new WebSocket(url);
 
           ws.addEventListener("message", async (event) => {
-            const data = typeof event.data === "string" ? event.data : await event.data.text();
-            const { user = "system", message = "" } = data.startsWith("{")
-              ? JSON.parse(data)
-              : { message: data };
+            const message = typeof event.data === "string" ? event.data : await event.data.text();
             log(
-              user,
+              "",
               typeof message === "string" ? message : JSON.stringify(message),
             );
           });

--- a/test/fixture/cloudflare-durable.ts
+++ b/test/fixture/cloudflare-durable.ts
@@ -27,6 +27,11 @@ export default {
 };
 
 export class $DurableObject extends DurableObject {
+  constructor(state: DurableObjectState, env: Record<string, any>) {
+    super(state, env);
+    ws.handleDurableInit(this, state, env);
+  }
+
   fetch(request: Request) {
     return ws.handleDurableUpgrade(this, request);
   }


### PR DESCRIPTION
When the cloudflare durable object is restored, websocket peers are created again, causing the reset request data and id.

Since both request URL and id are vital to write routing and state preserve logic, they are stored in in-memory limited state (2048 bytes) and automatically restored.

This PR also adds docs and stub for accessing durable init (state) object for future integrations.

