### PR TITLE
refactor!: remove adapter hooks

### DIFF
--- a/docs/2.adapters/bun.md
+++ b/docs/2.adapters/bun.md
@@ -32,16 +32,6 @@ Bun.serve({
 });
 ```
 
-## Adapter Hooks
-
-- `bun:message (peer, ws, message)`
-- `bun:open (peer, ws)`
-- `bun:close (peer, ws)`
-- `bun:drain (peer)`
-- `bun:error (peer, ws, error)`
-- `bun:ping (peer, ws, data)`
-- `bun:pong (peer, ws, data)`
-
 ::read-more
 See [`test/fixture/bun.ts`](https://github.com/unjs/crossws/blob/main/test/fixture/bun.ts) for demo and [`src/adapters/bun.ts`](https://github.com/unjs/crossws/blob/main/src/adapters/bun.ts) for implementation.
 ::

--- a/docs/2.adapters/cloudflare.md
+++ b/docs/2.adapters/cloudflare.md
@@ -33,13 +33,6 @@ export default {
 };
 ```
 
-## Adapter Hooks
-
-- `cloudflare:accept (peer)`
-- `cloudflare:message (peer, event)`
-- `cloudflare:error (peer, event)`
-- `cloudflare:close (peer, event)`
-
 ::read-more
 See [`test/fixture/cloudflare.ts`](https://github.com/unjs/crossws/blob/main/test/fixture/cloudflare.ts) for demo and [`src/adapters/cloudflare.ts`](https://github.com/unjs/crossws/blob/main/src/adapters/cloudflare.ts) for implementation.
 ::

--- a/docs/2.adapters/deno.md
+++ b/docs/2.adapters/deno.md
@@ -28,13 +28,6 @@ Deno.serve({ port: 3000 }, (request, info) => {
 });
 ```
 
-## Adapter Hooks
-
-- `deno:open (peer)`
-- `deno:message (peer, event)`
-- `deno:close (peer)`
-- `deno:error (peer, error)`
-
 ::read-more
 See [`test/fixture/deno.ts`](./test/fixture/deno.ts) for demo and [`src/adapters/deno.ts`](./src/adapters/deno.ts) for implementation.
 ::

--- a/docs/2.adapters/node.md
+++ b/docs/2.adapters/node.md
@@ -61,17 +61,6 @@ server.listen(3001, () => {
 });
 ```
 
-## Adapter Hooks
-
-- `uws:open (ws)`
-- `uws:message (ws, message, isBinary)`
-- `uws:close (ws, code, message)`
-- `uws:ping (ws, message)`
-- `uws:pong (ws, message)`
-- `uws:drain (ws)`
-- `uws:upgrade (res, req, context)`
-- `uws:subscription (ws, topic, newCount, oldCount)`
-
 ::read-more
 See [`test/fixture/node-uws.ts`](https://github.com/unjs/crossws/blob/main/test/fixture/node-uws.ts) for demo and [`src/adapters/node-uws.ts`](https://github.com/unjs/crossws/blob/main/src/adapters/node-uws.ts) for implementation.
 ::

--- a/docs/2.adapters/node.md
+++ b/docs/2.adapters/node.md
@@ -27,17 +27,6 @@ const server = createServer((req, res) => {
 server.on("upgrade", ws.handleUpgrade);
 ```
 
-## Adapter Hooks
-
-- `node:open (peer)`
-- `node:message (peer, data, isBinary)`
-- `node:close (peer, code, reason)`
-- `node:error (peer, error)`
-- `node:ping (peer)`
-- `node:pong (peer)`
-- `node:unexpected-response (peer, req, res)`
-- `node:upgrade (peer, req)`
-
 ::read-more
 See [`test/fixture/node.ts`](https://github.com/unjs/crossws/blob/main/test/fixture/node.ts) for demo and [`src/adapters/node.ts`](https://github.com/unjs/crossws/blob/main/src/adapters/node.ts) for implementation.
 ::

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { AdapterHooks, Hooks, ResolveHooks } from "./hooks.ts";
+import type { Hooks, ResolveHooks } from "./hooks.ts";
 import type { Peer } from "./peer.ts";
 
 export function adapterUtils(peers: Set<Peer>) {
@@ -24,7 +24,6 @@ export interface AdapterInstance {
 export interface AdapterOptions {
   resolve?: ResolveHooks;
   hooks?: Hooks;
-  adapterHooks?: AdapterHooks;
 }
 
 export type Adapter<

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -54,26 +54,12 @@ export default defineWebSocketAdapter<BunAdapter, BunOptions>(
         open: (ws) => {
           const peer = getPeer(ws, peers);
           peers.add(peer);
-          hooks.callAdapterHook("bun:open", peer, ws);
           hooks.callHook("open", peer);
         },
         close: (ws) => {
           const peer = getPeer(ws, peers);
           peers.delete(peer);
-          hooks.callAdapterHook("bun:close", peer, ws);
           hooks.callHook("close", peer, {});
-        },
-        drain: (ws) => {
-          const peer = getPeer(ws, peers);
-          hooks.callAdapterHook("bun:drain", peer);
-        },
-        ping(ws, data) {
-          const peer = getPeer(ws, peers);
-          hooks.callAdapterHook("bun:ping", peer, ws, data);
-        },
-        pong(ws, data) {
-          const peer = getPeer(ws, peers);
-          hooks.callAdapterHook("bun:pong", peer, ws, data);
         },
       },
     };

--- a/src/adapters/cloudflare-durable.ts
+++ b/src/adapters/cloudflare-durable.ts
@@ -45,7 +45,6 @@ export default defineWebSocketAdapter<
       );
       peers.add(peer);
       (obj as DurableObjectPub).ctx.acceptWebSocket(server);
-      await hooks.callAdapterHook("cloudflare:accept", peer);
       await hooks.callHook("open", peer);
       // eslint-disable-next-line unicorn/no-null
       return new Response(null, {
@@ -56,14 +55,12 @@ export default defineWebSocketAdapter<
     },
     handleDurableMessage: async (obj, ws, message) => {
       const peer = CloudflareDurablePeer._restore(obj, ws as CF.WebSocket);
-      await hooks.callAdapterHook("cloudflare:message", peer, message);
       await hooks.callHook("message", peer, new Message(message, peer));
     },
     handleDurableClose: async (obj, ws, code, reason, wasClean) => {
       const peer = CloudflareDurablePeer._restore(obj, ws as CF.WebSocket);
       peers.delete(peer);
       const details = { code, reason, wasClean };
-      await hooks.callAdapterHook("cloudflare:close", peer, details);
       await hooks.callHook("close", peer, details);
     },
   };

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -53,10 +53,8 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
         });
         peers.add(peer);
         server.accept();
-        hooks.callAdapterHook("cloudflare:accept", peer);
         hooks.callHook("open", peer);
         server.addEventListener("message", (event) => {
-          hooks.callAdapterHook("cloudflare:message", peer, event);
           hooks.callHook(
             "message",
             peer,
@@ -65,12 +63,10 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
         });
         server.addEventListener("error", (event) => {
           peers.delete(peer);
-          hooks.callAdapterHook("cloudflare:error", peer, event);
           hooks.callHook("error", peer, new WSError(event.error));
         });
         server.addEventListener("close", (event) => {
           peers.delete(peer);
-          hooks.callAdapterHook("cloudflare:close", peer, event);
           hooks.callHook("close", peer, event);
         });
         // eslint-disable-next-line unicorn/no-null

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -51,21 +51,17 @@ export default defineWebSocketAdapter<DenoAdapter, DenoOptions>(
         });
         peers.add(peer);
         upgrade.socket.addEventListener("open", () => {
-          hooks.callAdapterHook("deno:open", peer);
           hooks.callHook("open", peer);
         });
         upgrade.socket.addEventListener("message", (event) => {
-          hooks.callAdapterHook("deno:message", peer, event);
           hooks.callHook("message", peer, new Message(event.data, peer, event));
         });
         upgrade.socket.addEventListener("close", () => {
           peers.delete(peer);
-          hooks.callAdapterHook("deno:close", peer);
           hooks.callHook("close", peer, {});
         });
         upgrade.socket.addEventListener("error", (error) => {
           peers.delete(peer);
-          hooks.callAdapterHook("deno:error", peer, error);
           hooks.callHook("error", peer, new WSError(error));
         });
         return upgrade.response;

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -53,10 +53,8 @@ export default defineWebSocketAdapter<NodeAdapter, NodeOptions>(
       const request = new NodeReqProxy(nodeReq);
       const peer = new NodePeer({ ws, request, peers, nodeReq });
       peers.add(peer);
-      ws.on("open", () => {
-        hooks.callHook("open", peer);
-      });
-      ws.on("message", (data: unknown, isBinary: boolean) => {
+      hooks.callHook("open", peer); // ws is already open
+      ws.on("message", (data: unknown) => {
         if (Array.isArray(data)) {
           data = Buffer.concat(data);
         }

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -54,7 +54,6 @@ export default defineWebSocketAdapter<UWSAdapter, UWSOptions>(
           ((peer as any)._internal.ws as UwsWebSocketProxy).readyState =
             2 /* CLOSING */;
           peers.delete(peer);
-          hooks.callAdapterHook("uws:close", peer, ws, code, message);
           hooks.callHook("close", peer, {
             code,
             reason: message?.toString(),
@@ -62,39 +61,14 @@ export default defineWebSocketAdapter<UWSAdapter, UWSOptions>(
           ((peer as any)._internal.ws as UwsWebSocketProxy).readyState =
             3 /* CLOSED */;
         },
-        drain(ws) {
-          const peer = getPeer(ws, peers);
-          hooks.callAdapterHook("uws:drain", peer, ws);
-        },
         message(ws, message, isBinary) {
           const peer = getPeer(ws, peers);
-          hooks.callAdapterHook("uws:message", peer, ws, message, isBinary);
           hooks.callHook("message", peer, new Message(message, peer));
         },
         open(ws) {
           const peer = getPeer(ws, peers);
           peers.add(peer);
-          hooks.callAdapterHook("uws:open", peer, ws);
           hooks.callHook("open", peer);
-        },
-        ping(ws, message) {
-          const peer = getPeer(ws, peers);
-          hooks.callAdapterHook("uws:ping", peer, ws, message);
-        },
-        pong(ws, message) {
-          const peer = getPeer(ws, peers);
-          hooks.callAdapterHook("uws:pong", peer, ws, message);
-        },
-        subscription(ws, topic, newCount, oldCount) {
-          const peer = getPeer(ws, peers);
-          hooks.callAdapterHook(
-            "uws:subscription",
-            peer,
-            ws,
-            topic,
-            newCount,
-            oldCount,
-          );
         },
         async upgrade(res, req, context) {
           let aborted = false;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -39,13 +39,6 @@ export class AdapterHookable {
       },
     ) as Promise<any>;
   }
-
-  callAdapterHook<N extends keyof AdapterHooks>(
-    name: N,
-    ...args: Parameters<AdapterHooks[N]>
-  ): ReturnType<AdapterHooks[N]> {
-    return this.options.adapterHooks?.[name]?.apply(undefined, args);
-  }
 }
 
 // --- types ---
@@ -92,49 +85,4 @@ export interface Hooks {
 
   /** An error occurs */
   error: (peer: Peer, error: WSError) => MaybePromise<void>;
-}
-
-export interface AdapterHooks extends Record<string, HookFn<any[], any>> {
-  // Bun
-  "bun:message": HookFn<[ws: any, message: any]>;
-  "bun:open": HookFn<[ws: any]>;
-  "bun:close": HookFn<[ws: any]>;
-  "bun:drain": HookFn<[]>;
-  "bun:error": HookFn<[ws: any, error: any]>;
-  "bun:ping": HookFn<[ws: any, data: any]>;
-  "bun:pong": HookFn<[ws: any, data: any]>;
-
-  // Cloudflare
-  "cloudflare:accept": HookFn<[]>;
-  "cloudflare:message": HookFn<[event: any]>;
-  "cloudflare:error": HookFn<[event: any]>;
-  "cloudflare:close": HookFn<[event: any]>;
-
-  // Deno
-  "deno:open": HookFn<[]>;
-  "deno:message": HookFn<[event: any]>;
-  "deno:close": HookFn<[]>;
-  "deno:error": HookFn<[error: any]>;
-
-  // ws (Node)
-  "node:open": HookFn<[]>;
-  "node:message": HookFn<[data: any, isBinary: boolean]>;
-  "node:close": HookFn<[code: number, reason: Buffer]>;
-  "node:error": HookFn<[error: any]>;
-  "node:ping": HookFn<[data: Buffer]>;
-  "node:pong": HookFn<[data: Buffer]>;
-  "node:unexpected-response": HookFn<[req: any, res: any]>;
-  "node:upgrade": HookFn<[req: any]>;
-
-  // uws (Node)
-  "uws:open": HookFn<[ws: any]>;
-  "uws:message": HookFn<[ws: any, message: any, isBinary: boolean]>;
-  "uws:close": HookFn<[ws: any, code: number, message: any]>;
-  "uws:ping": HookFn<[ws: any, message: any]>;
-  "uws:pong": HookFn<[ws: any, message: any]>;
-  "uws:drain": HookFn<[ws: any]>;
-  "uws:upgrade": HookFn<[res: any, req: any, context: any]>;
-  "uws:subscription": HookFn<
-    [ws: any, topic: any, newCount: number, oldCount: number]
-  >;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 // Hooks
 export { defineHooks } from "./hooks.ts";
-export type { Hooks, AdapterHooks, ResolveHooks } from "./hooks.ts";
+export type { Hooks, ResolveHooks } from "./hooks.ts";
 
 // Adapter
 export { defineWebSocketAdapter } from "./adapter.ts";

--- a/test/_utils.ts
+++ b/test/_utils.ts
@@ -138,7 +138,7 @@ class WebSocketInspector extends Agent {
 
 export function wsTestsExec(
   cmd: string,
-  opts: Parameters<typeof wsTests>[1],
+  opts: Parameters<typeof wsTests>[1] & { silent?: boolean },
   tests = wsTests,
 ) {
   let childProc: ExecaRes;
@@ -156,9 +156,12 @@ export function wsTestsExec(
         console.error(error);
       }
     });
-    childProc.stderr!.on("data", (chunk) => {
-      console.log(chunk.toString());
-    });
+    if (process.env.TEST_DEBUG || !opts.silent) {
+      console.log("hooking stderr");
+      childProc.stderr!.on("data", (chunk) => {
+        console.log(chunk.toString());
+      });
+    }
     if (process.env.TEST_DEBUG) {
       childProc.stdout!.on("data", (chunk) => {
         console.log(chunk.toString());

--- a/test/_utils.ts
+++ b/test/_utils.ts
@@ -157,7 +157,6 @@ export function wsTestsExec(
       }
     });
     if (process.env.TEST_DEBUG || !opts.silent) {
-      console.log("hooking stderr");
       childProc.stderr!.on("data", (chunk) => {
         console.log(chunk.toString());
       });

--- a/test/adapters/cloudflare.test.ts
+++ b/test/adapters/cloudflare.test.ts
@@ -4,6 +4,6 @@ import { wsTestsExec } from "../_utils";
 describe("cloudflare", () => {
   wsTestsExec(
     "wrangler dev -c ./wrangler.toml --inspector-port 0 --port $PORT",
-    { adapter: "cloudflare", pubsub: false },
+    { adapter: "cloudflare", pubsub: false, silent: true },
   );
 });


### PR DESCRIPTION
The initial idea behind adapter hooks was to allow an escape hatch over abstractions.

During development and integrations, they actually wasn't useful at all and current ~33 additional hooks could only make runtime slower, besides they were not resolvable so not compatible with application routers (and in top level users anyway have power to hook into more)

This PR removes them but we might add back some adapter specific hooks under normal hooks if needed.