### PR TITLE
chore(examples): fix typo

### DIFF
--- a/examples/h3/public/index.html
+++ b/examples/h3/public/index.html
@@ -74,7 +74,7 @@
 
         ws.addEventListener("message", async (event) => {
           let data =
-            typeof event.data === "string" ? data : await event.data.text();
+            typeof event.data === "string" ? event.data : await event.data.text();
           const { user = "system", message = "" } = data.startsWith("{")
             ? JSON.parse(data)
             : { message: data };


### PR DESCRIPTION
The "data" is wrong. It is used before initialization.
To solve this problem, "event.data" must be used.