### PR TITLE
docs: add `destr` tip for JSON parsing

### DIFF
--- a/docs/1.guide/4.message.md
+++ b/docs/1.guide/4.message.md
@@ -43,6 +43,12 @@ If raw data is in any other format, it will be automatically converted or decode
 
 Get parsed version of the message text with [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
 
+> [!TIP] 
+> While `JSON.parse()` is safe against prototype pollution, to achieve parsing with fallback support you can use [UnJS's `destr`](https://github.com/unjs/destr):
+> ```ts
+> const data = destr(await message.text());
+> ```
+
 ### `message.uint8Array()`
 
 Get data as [`Uint8Array`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array) value.

--- a/docs/1.guide/4.message.md
+++ b/docs/1.guide/4.message.md
@@ -43,9 +43,14 @@ If raw data is in any other format, it will be automatically converted or decode
 
 Get parsed version of the message text with [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
 
-> [!TIP] 
-> While `JSON.parse()` is safe against prototype pollution, to achieve parsing with fallback support you can use [UnJS's `destr`](https://github.com/unjs/destr):
+> [!TIP]
+> You can optionally use [`destr`](https://github.com/unjs/destr) to safely parse message object:
+>
+> - Does not throws error if input is not a JSON but fall backs to text.
+> - Removes any field that can potentially cause prototype pollution vulnterability in usage.
+>
 > ```ts
+> import { destr } from "destr";
 > const data = destr(await message.text());
 > ```
 

--- a/docs/1.guide/4.message.md
+++ b/docs/1.guide/4.message.md
@@ -44,13 +44,11 @@ If raw data is in any other format, it will be automatically converted or decode
 Get parsed version of the message text with [`JSON.parse()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse).
 
 > [!TIP]
-> You can optionally use [`destr`](https://github.com/unjs/destr) to safely parse message object:
+> You can optionally use [`unjs/destr`](https://github.com/unjs/destr) to safely parse the message object.
 >
-> - Does not throws error if input is not a JSON but fall backs to text.
-> - Removes any field that can potentially cause prototype pollution vulnterability in usage.
+> It does not throw an error if the input is not valid JSON but falls back to text and also removes any fields that could potentially cause prototype pollution vulnerabilities.
 >
 > ```ts
-> import { destr } from "destr";
 > const data = destr(await message.text());
 > ```
 


### PR DESCRIPTION
Mentioned in https://github.com/unjs/crossws/issues/108#issuecomment-2600989980: adding a small tip to `message.json()` for parsing JSON strings using `destr`