### PR TITLE
feat(peer): support `context`

### DIFF
--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -33,7 +33,14 @@ The IP address of the client.
 Direct access to the [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) instance.
 
 > [!NOTE]
-> WebSocket properties vary across runtimes. When accessing `peer.websocket`, a lightweight proxy increases stablity. Refer to the [compatibility table](#compatibility) for more info.
+> WebSocket properties vary across runtimes. When accessing `peer.websocket`, a lightweight proxy increases stability. Refer to the [compatibility table](#compatibility) for more info.
+
+### `peer.context`
+
+The context is an object that contains arbitrary information about the request.
+
+> [!NOTE]
+> context data can be volatile in some runtimes.
 
 ## Instance methods
 

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -14,8 +14,11 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
 
   #ws?: Partial<web.WebSocket>;
 
+  readonly context: Record<string, unknown>;
+
   constructor(internal: Internal) {
     this._topics = new Set();
+    this.context = {};
     this._internal = internal;
   }
 


### PR DESCRIPTION
This PR adds `peer.context` to allow storing arbitrary data such as session info.

This allows API compatibility with [`h3.event.context`](https://h3.unjs.io/guide/event#eventcontext)