### PR TITLE
feat: shared context between `upgrade` hook and `peer`

### DIFF
--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -19,6 +19,7 @@ type ContextData = {
   peer?: BunPeer;
   request: Request;
   server?: Server;
+  context: Peer["context"];
 };
 
 // --- adapter ---
@@ -31,7 +32,8 @@ export default defineWebSocketAdapter<BunAdapter, BunOptions>(
     return {
       ...adapterUtils(peers),
       async handleUpgrade(request, server) {
-        const { upgradeHeaders, endResponse } = await hooks.upgrade(request);
+        const { upgradeHeaders, endResponse, context } =
+          await hooks.upgrade(request);
         if (endResponse) {
           return endResponse;
         }
@@ -39,6 +41,7 @@ export default defineWebSocketAdapter<BunAdapter, BunOptions>(
           data: {
             server,
             request,
+            context,
           } satisfies ContextData,
           headers: upgradeHeaders,
         });
@@ -91,6 +94,10 @@ class BunPeer extends Peer<{
 }> {
   get remoteAddress() {
     return this._internal.ws.remoteAddress;
+  }
+
+  get context() {
+    return this._internal.ws.data.context;
   }
 
   send(data: unknown, options?: { compress?: boolean }) {

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -32,8 +32,8 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
     const peers = new Set<CloudflarePeer>();
     return {
       ...adapterUtils(peers),
-      handleUpgrade: async (request, env, context) => {
-        const { upgradeHeaders, endResponse } = await hooks.upgrade(
+      handleUpgrade: async (request, env, cfCtx) => {
+        const { upgradeHeaders, endResponse, context } = await hooks.upgrade(
           request as unknown as Request,
         );
         if (endResponse) {
@@ -49,7 +49,8 @@ export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
           wsServer: server,
           request: request as unknown as Request,
           cfEnv: env,
-          cfCtx: context,
+          cfCtx: cfCtx,
+          context,
         });
         peers.add(peer);
         server.accept();
@@ -89,6 +90,7 @@ class CloudflarePeer extends Peer<{
   wsServer: _cf.WebSocket;
   cfEnv: unknown;
   cfCtx: _cf.ExecutionContext;
+  context: Peer["context"];
 }> {
   send(data: unknown) {
     this._internal.wsServer.send(toBufferLike(data));

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -31,7 +31,8 @@ export default defineWebSocketAdapter<DenoAdapter, DenoOptions>(
     return {
       ...adapterUtils(peers),
       handleUpgrade: async (request, info) => {
-        const { upgradeHeaders, endResponse } = await hooks.upgrade(request);
+        const { upgradeHeaders, endResponse, context } =
+          await hooks.upgrade(request);
         if (endResponse) {
           return endResponse;
         }
@@ -45,6 +46,7 @@ export default defineWebSocketAdapter<DenoAdapter, DenoOptions>(
           request,
           peers,
           denoInfo: info,
+          context,
         });
         peers.add(peer);
         upgrade.socket.addEventListener("open", () => {
@@ -74,6 +76,7 @@ class DenoPeer extends Peer<{
   request: Request;
   peers: Set<DenoPeer>;
   denoInfo: ServeHandlerInfo;
+  context: Peer["context"];
 }> {
   get remoteAddress() {
     return this._internal.denoInfo.remoteAddr?.hostname;

--- a/src/adapters/sse.ts
+++ b/src/adapters/sse.ts
@@ -27,7 +27,8 @@ export default defineWebSocketAdapter<SSEAdapter, SSEOptions>((opts = {}) => {
   return {
     ...adapterUtils(peers),
     fetch: async (request: Request) => {
-      const { upgradeHeaders, endResponse } = await hooks.upgrade(request);
+      const { upgradeHeaders, endResponse, context } =
+        await hooks.upgrade(request);
       if (endResponse) {
         return endResponse;
       }
@@ -60,6 +61,7 @@ export default defineWebSocketAdapter<SSEAdapter, SSEOptions>((opts = {}) => {
           request,
           hooks,
           ws,
+          context,
         });
         peers.add(peer);
         if (opts.bidir) {
@@ -98,6 +100,7 @@ class SSEPeer extends Peer<{
   request: Request;
   ws: SSEWebSocketStub;
   hooks: AdapterHookable;
+  context: Peer["context"];
 }> {
   _sseStream: ReadableStream; // server -> client
   _sseStreamController?: ReadableStreamDefaultController;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -40,7 +40,9 @@ export class AdapterHookable {
     ) as Promise<any>;
   }
 
-  async upgrade(request: UpgradeRequest & { context?: any }): Promise<{
+  async upgrade(
+    request: UpgradeRequest & { context?: Peer["context"] },
+  ): Promise<{
     upgradeHeaders?: HeadersInit;
     endResponse?: Response;
     context: Peer["context"];

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -5,6 +5,7 @@ export interface AdapterInternal {
   ws: unknown;
   request?: Request | Partial<Request>;
   peers?: Set<Peer>;
+  context?: Peer["context"];
 }
 
 export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
@@ -14,12 +15,13 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
 
   #ws?: Partial<web.WebSocket>;
 
-  readonly context: Record<string, unknown>;
-
   constructor(internal: Internal) {
     this._topics = new Set();
-    this.context = {};
     this._internal = internal;
+  }
+
+  get context(): Record<string, unknown> {
+    return (this._internal.context ??= {});
   }
 
   /**

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -28,6 +28,7 @@ export function createDemo<T extends Adapter<any, any>>(
           peer.send({
             id: peer.id,
             remoteAddress: peer.remoteAddress,
+            context: peer.context,
             request: {
               url: peer.request?.url,
               headers: Object.fromEntries(peer.request?.headers || []),
@@ -63,6 +64,7 @@ export function createDemo<T extends Adapter<any, any>>(
           headers: { "x-error": "unauthorized" },
         });
       }
+      req.context.test = "1";
       return {
         headers: {
           "x-powered-by": "cross-ws",

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -69,7 +69,7 @@ export function wsTests(getURL: () => string, opts: WSTestOpts) {
       headers: { "x-test": "1" },
     });
     await ws.send("debug");
-    const { request, remoteAddress } = await ws.next();
+    const { request, remoteAddress, context } = await ws.next();
 
     // Headers
     if (opts.adapter === "sse") {
@@ -87,6 +87,11 @@ export function wsTests(getURL: () => string, opts: WSTestOpts) {
     // Remote address
     if (!/sse|cloudflare/.test(opts.adapter)) {
       expect(remoteAddress).toMatch(/:{2}1|(?:0{4}:){7}0{3}1|127\.0\.\0\.1/);
+    }
+
+    // Context
+    if (opts.adapter !== "cloudflare-durable") {
+      expect(context.test).toBe("1");
     }
   });
 


### PR DESCRIPTION
Followup on #110 

This PR adds `request.context` available to the `upgrade` hook which is a shared object with `peer`.

Useful for preserving state from upgrades such as authentication and sessions.