### PR TITLE
Investigating CI/Lint type issues

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -66,11 +66,14 @@ export class AdapterHookable {
         };
       }
     } catch (error) {
-      const errResponse = (error as { response: Response }).response || error;
-      if (errResponse instanceof Response) {
+      if (
+        error instanceof Response ||
+        (error && typeof error === "object" && "response" in error && typeof error.response === "function")
+      ) {
+        const response = error instanceof Response ? error : (error as { response: () => Response }).response();
         return {
           context,
-          endResponse: errResponse,
+          endResponse: response,
         };
       }
       throw error;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,5 +16,6 @@
       "@cloudflare/workers-types",
       "deno"
     ]
-  }
+  },
+  "exclude": ["examples"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,20 @@
 {
   "compilerOptions": {
-    "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
-    "esModuleInterop": true,
+    "allowJs": true,
+    "checkJs": true,
     "skipLibCheck": true,
+    "target": "esnext",
+		"module": "esnext",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
     "strict": true,
     "allowImportingTsExtensions": true,
+    "allowSyntheticDefaultImports": true,
     "noEmit": true,
-    "types": ["node", "@cloudflare/workers-types", "deno"]
-  },
-  "include": ["src", "test"]
+    "types": [
+      "node",
+      "@cloudflare/workers-types",
+      "deno"
+    ]
+  }
 }


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

CI is failing on this PR: https://github.com/sveltejs/kit/pull/12973

Digging into it and running TSC directly in the repo supplies a different set of linting error I'm attempting to address here, but in doing the digging I came across another interesting issue, the build script in this repo introduces a number of TS Linting errors post build.

Running the below commands in this order should demonstrate the issues, and could be causing some of the upstream issues we are seeing.

### Standing state of the code

Produces one TS error regarding the `eslint` config

``` bash
pnpm i
```
``` bash
tsc 
```
### Post-Build state of the code

Produces a number of other errors that will be picked up via 
the `dist` folder in `node_modules` in other packages when tsc is run

``` bash
pnpm build
```
``` bash
tsc 
```

I'm not sure that all of this needs to be fully addressed to unblock that PR, but I would love assistance with the error below:
```
../../node_modules/.pnpm/crossws@0.3.3/node_modules/crossws/dist/index.d.mts(88,19): error TS2315: Type 'Uint8Array' is not generic.
```