### PR TITLE
fix(node, uws): send data as blob only if it is not string

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -128,7 +128,7 @@ class NodePeer extends Peer<{
 
   send(data: unknown, options?: { compress?: boolean }) {
     const dataBuff = toBufferLike(data);
-    const isBinary = typeof data !== "string";
+    const isBinary = typeof dataBuff !== "string";
     this._internal.ws.send(dataBuff, {
       compress: options?.compress,
       binary: isBinary,

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -176,7 +176,7 @@ class UWSPeer extends Peer<{
 
   send(data: unknown, options?: { compress?: boolean }) {
     const dataBuff = toBufferLike(data);
-    const isBinary = typeof data !== "string";
+    const isBinary = typeof dataBuff !== "string";
     return this._internal.uws.send(dataBuff, isBinary, options?.compress);
   }
 


### PR DESCRIPTION
resolves https://github.com/unjs/crossws/issues/122

current binary test isn't working (see https://github.com/unjs/crossws/issues/123), I think it should be discussed how this is going to be resolved before I will create a test for this