### PR TITLE
fix: specify an explicit return type for `uint8Array()`

### DIFF
--- a/src/message.ts
+++ b/src/message.ts
@@ -41,7 +41,7 @@ export class Message implements Partial<MessageEvent> {
    *
    * If raw data is in any other format or string, it will be automatically converted and encoded.
    */
-  uint8Array() {
+  uint8Array(): Uint8Array {
     // Cached
     const _uint8Array = this.#uint8Array;
     if (_uint8Array) {


### PR DESCRIPTION
fixes https://github.com/unjs/crossws/issues/127

An alternative to https://github.com/unjs/crossws/pull/126

By explicitly specifying the return type as `Uint8Array`, TypeScript won't infer the return type for us and compile it as the generic form `Uint8Array<ArrayBufferLike>` which is only available on TS >5.7. This allows us to maintain compatibility with libraries using TypeScript <5.7 while still returning the same type.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
