### PR TITLE
refactor: stricter type declarations

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,7 +1,7 @@
 import type { Hooks, ResolveHooks } from "./hooks.ts";
 import type { Peer } from "./peer.ts";
 
-export function adapterUtils(peers: Set<Peer>) {
+export function adapterUtils(peers: Set<Peer>): AdapterInstance {
   return {
     peers,
     publish(topic: string, message: any, options) {
@@ -34,6 +34,6 @@ export type Adapter<
 export function defineWebSocketAdapter<
   AdapterT extends AdapterInstance = AdapterInstance,
   Options extends AdapterOptions = AdapterOptions,
->(factory: Adapter<AdapterT, Options>) {
+>(factory: Adapter<AdapterT, Options>): Adapter<AdapterT, Options> {
   return factory;
 }

--- a/src/adapters/cloudflare-durable.ts
+++ b/src/adapters/cloudflare-durable.ts
@@ -1,7 +1,7 @@
-import type { AdapterOptions, AdapterInstance } from "../adapter.ts";
+import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import type * as web from "../../types/web.ts";
 import { toBufferLike } from "../utils.ts";
-import { defineWebSocketAdapter, adapterUtils } from "../adapter.ts";
+import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { Peer } from "../peer.ts";
@@ -11,10 +11,10 @@ import type { DurableObject } from "cloudflare:workers";
 
 // https://developers.cloudflare.com/durable-objects/examples/websocket-hibernation-server/
 
-export default defineWebSocketAdapter<
+const cloudflareDurableAdapter: Adapter<
   CloudflareDurableAdapter,
   CloudflareOptions
->((opts) => {
+> = (opts) => {
   const hooks = new AdapterHookable(opts);
   const peers = new Set<CloudflareDurablePeer>();
   return {
@@ -68,7 +68,9 @@ export default defineWebSocketAdapter<
       await hooks.callHook("close", peer, details);
     },
   };
-});
+};
+
+export default cloudflareDurableAdapter;
 
 // --- peer ---
 
@@ -78,7 +80,7 @@ class CloudflareDurablePeer extends Peer<{
   peers?: never;
   durable: DurableObjectPub;
 }> {
-  get peers() {
+  override get peers() {
     return new Set(
       this.#getwebsockets().map((ws) =>
         CloudflareDurablePeer._restore(this._internal.durable, ws),
@@ -94,7 +96,7 @@ class CloudflareDurablePeer extends Peer<{
     return this._internal.ws.send(toBufferLike(data));
   }
 
-  subscribe(topic: string): void {
+  override subscribe(topic: string): void {
     super.subscribe(topic);
     const state = getAttachedState(this._internal.ws);
     if (!state.t) {

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -1,6 +1,6 @@
-import type { AdapterOptions, AdapterInstance } from "../adapter.ts";
+import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import { toBufferLike } from "../utils.ts";
-import { defineWebSocketAdapter, adapterUtils } from "../adapter.ts";
+import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
@@ -26,60 +26,62 @@ export interface CloudflareOptions extends AdapterOptions {}
 // --- adapter ---
 
 // https://developers.cloudflare.com/workers/examples/websockets/
-export default defineWebSocketAdapter<CloudflareAdapter, CloudflareOptions>(
-  (options = {}) => {
-    const hooks = new AdapterHookable(options);
-    const peers = new Set<CloudflarePeer>();
-    return {
-      ...adapterUtils(peers),
-      handleUpgrade: async (request, env, cfCtx) => {
-        const { upgradeHeaders, endResponse, context } = await hooks.upgrade(
-          request as unknown as Request,
-        );
-        if (endResponse) {
-          return endResponse as unknown as _cf.Response;
-        }
+const cloudflareAdapter: Adapter<CloudflareAdapter, CloudflareOptions> = (
+  options = {},
+) => {
+  const hooks = new AdapterHookable(options);
+  const peers = new Set<CloudflarePeer>();
+  return {
+    ...adapterUtils(peers),
+    handleUpgrade: async (request, env, cfCtx) => {
+      const { upgradeHeaders, endResponse, context } = await hooks.upgrade(
+        request as unknown as Request,
+      );
+      if (endResponse) {
+        return endResponse as unknown as _cf.Response;
+      }
 
-        const pair = new WebSocketPair();
-        const client = pair[0];
-        const server = pair[1];
-        const peer = new CloudflarePeer({
-          ws: client,
-          peers,
-          wsServer: server,
-          request: request as unknown as Request,
-          cfEnv: env,
-          cfCtx: cfCtx,
-          context,
-        });
-        peers.add(peer);
-        server.accept();
-        hooks.callHook("open", peer);
-        server.addEventListener("message", (event) => {
-          hooks.callHook(
-            "message",
-            peer,
-            new Message(event.data, peer, event as MessageEvent),
-          );
-        });
-        server.addEventListener("error", (event) => {
-          peers.delete(peer);
-          hooks.callHook("error", peer, new WSError(event.error));
-        });
-        server.addEventListener("close", (event) => {
-          peers.delete(peer);
-          hooks.callHook("close", peer, event);
-        });
-        // eslint-disable-next-line unicorn/no-null
-        return new Response(null, {
-          status: 101,
-          webSocket: client,
-          headers: upgradeHeaders,
-        });
-      },
-    };
-  },
-);
+      const pair = new WebSocketPair();
+      const client = pair[0];
+      const server = pair[1];
+      const peer = new CloudflarePeer({
+        ws: client,
+        peers,
+        wsServer: server,
+        request: request as unknown as Request,
+        cfEnv: env,
+        cfCtx: cfCtx,
+        context,
+      });
+      peers.add(peer);
+      server.accept();
+      hooks.callHook("open", peer);
+      server.addEventListener("message", (event) => {
+        hooks.callHook(
+          "message",
+          peer,
+          new Message(event.data, peer, event as MessageEvent),
+        );
+      });
+      server.addEventListener("error", (event) => {
+        peers.delete(peer);
+        hooks.callHook("error", peer, new WSError(event.error));
+      });
+      server.addEventListener("close", (event) => {
+        peers.delete(peer);
+        hooks.callHook("close", peer, event);
+      });
+      // eslint-disable-next-line unicorn/no-null
+      return new Response(null, {
+        status: 101,
+        webSocket: client,
+        headers: upgradeHeaders,
+      });
+    },
+  };
+};
+
+export default cloudflareAdapter;
 
 // --- peer ---
 

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -1,6 +1,6 @@
-import type { AdapterOptions, AdapterInstance } from "../adapter.ts";
+import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import { toBufferLike } from "../utils.ts";
-import { defineWebSocketAdapter, adapterUtils } from "../adapter.ts";
+import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
@@ -24,50 +24,50 @@ type ServeHandlerInfo = {
 // https://deno.land/api?s=WebSocket
 // https://deno.land/api?s=Deno.upgradeWebSocket
 // https://examples.deno.land/http-server-websocket
-export default defineWebSocketAdapter<DenoAdapter, DenoOptions>(
-  (options = {}) => {
-    const hooks = new AdapterHookable(options);
-    const peers = new Set<DenoPeer>();
-    return {
-      ...adapterUtils(peers),
-      handleUpgrade: async (request, info) => {
-        const { upgradeHeaders, endResponse, context } =
-          await hooks.upgrade(request);
-        if (endResponse) {
-          return endResponse;
-        }
+const denoAdapter: Adapter<DenoAdapter, DenoOptions> = (options = {}) => {
+  const hooks = new AdapterHookable(options);
+  const peers = new Set<DenoPeer>();
+  return {
+    ...adapterUtils(peers),
+    handleUpgrade: async (request, info) => {
+      const { upgradeHeaders, endResponse, context } =
+        await hooks.upgrade(request);
+      if (endResponse) {
+        return endResponse;
+      }
 
-        const upgrade = Deno.upgradeWebSocket(request, {
-          // @ts-expect-error https://github.com/denoland/deno/pull/22242
-          headers: upgradeHeaders,
-        });
-        const peer = new DenoPeer({
-          ws: upgrade.socket,
-          request,
-          peers,
-          denoInfo: info,
-          context,
-        });
-        peers.add(peer);
-        upgrade.socket.addEventListener("open", () => {
-          hooks.callHook("open", peer);
-        });
-        upgrade.socket.addEventListener("message", (event) => {
-          hooks.callHook("message", peer, new Message(event.data, peer, event));
-        });
-        upgrade.socket.addEventListener("close", () => {
-          peers.delete(peer);
-          hooks.callHook("close", peer, {});
-        });
-        upgrade.socket.addEventListener("error", (error) => {
-          peers.delete(peer);
-          hooks.callHook("error", peer, new WSError(error));
-        });
-        return upgrade.response;
-      },
-    };
-  },
-);
+      const upgrade = Deno.upgradeWebSocket(request, {
+        // @ts-expect-error https://github.com/denoland/deno/pull/22242
+        headers: upgradeHeaders,
+      });
+      const peer = new DenoPeer({
+        ws: upgrade.socket,
+        request,
+        peers,
+        denoInfo: info,
+        context,
+      });
+      peers.add(peer);
+      upgrade.socket.addEventListener("open", () => {
+        hooks.callHook("open", peer);
+      });
+      upgrade.socket.addEventListener("message", (event) => {
+        hooks.callHook("message", peer, new Message(event.data, peer, event));
+      });
+      upgrade.socket.addEventListener("close", () => {
+        peers.delete(peer);
+        hooks.callHook("close", peer, {});
+      });
+      upgrade.socket.addEventListener("error", (error) => {
+        peers.delete(peer);
+        hooks.callHook("error", peer, new WSError(error));
+      });
+      return upgrade.response;
+    },
+  };
+};
+
+export default denoAdapter;
 
 // --- peer ---
 
@@ -78,7 +78,7 @@ class DenoPeer extends Peer<{
   denoInfo: ServeHandlerInfo;
   context: Peer["context"];
 }> {
-  get remoteAddress() {
+  override get remoteAddress() {
     return this._internal.denoInfo.remoteAddr?.hostname;
   }
 
@@ -99,7 +99,7 @@ class DenoPeer extends Peer<{
     this._internal.ws.close(code, reason);
   }
 
-  terminate(): void {
+  override terminate(): void {
     (this._internal.ws as any).terminate();
   }
 }

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,7 +1,7 @@
-import type { AdapterOptions, AdapterInstance } from "../adapter.ts";
+import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import type { WebSocket } from "../../types/web.ts";
 import { toBufferLike } from "../utils.ts";
-import { defineWebSocketAdapter, adapterUtils } from "../adapter.ts";
+import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
@@ -38,77 +38,77 @@ export interface NodeOptions extends AdapterOptions {
 
 // https://github.com/websockets/ws
 // https://github.com/websockets/ws/blob/master/doc/ws.md
-export default defineWebSocketAdapter<NodeAdapter, NodeOptions>(
-  (options = {}) => {
-    const hooks = new AdapterHookable(options);
-    const peers = new Set<NodePeer>();
+const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
+  const hooks = new AdapterHookable(options);
+  const peers = new Set<NodePeer>();
 
-    const wss: WebSocketServer =
-      options.wss ||
-      (new _WebSocketServer({
-        noServer: true,
-        ...(options.serverOptions as any),
-      }) as WebSocketServer);
+  const wss: WebSocketServer =
+    options.wss ||
+    (new _WebSocketServer({
+      noServer: true,
+      ...(options.serverOptions as any),
+    }) as WebSocketServer);
 
-    wss.on("connection", (ws, nodeReq) => {
-      const request = new NodeReqProxy(nodeReq);
-      const peer = new NodePeer({ ws, request, peers, nodeReq });
-      peers.add(peer);
-      hooks.callHook("open", peer); // ws is already open
-      ws.on("message", (data: unknown) => {
-        if (Array.isArray(data)) {
-          data = Buffer.concat(data);
-        }
-        hooks.callHook("message", peer, new Message(data, peer));
-      });
-      ws.on("error", (error: Error) => {
-        peers.delete(peer);
-        hooks.callHook("error", peer, new WSError(error));
-      });
-      ws.on("close", (code: number, reason: Buffer) => {
-        peers.delete(peer);
-        hooks.callHook("close", peer, {
-          code,
-          reason: reason?.toString(),
-        });
-      });
-    });
-
-    wss.on("headers", (outgoingHeaders, req) => {
-      const upgradeHeaders = (req as AugmentedReq)._upgradeHeaders;
-      if (upgradeHeaders) {
-        for (const [key, value] of new Headers(upgradeHeaders)) {
-          outgoingHeaders.push(`${key}: ${value}`);
-        }
+  wss.on("connection", (ws, nodeReq) => {
+    const request = new NodeReqProxy(nodeReq);
+    const peer = new NodePeer({ ws, request, peers, nodeReq });
+    peers.add(peer);
+    hooks.callHook("open", peer); // ws is already open
+    ws.on("message", (data: unknown) => {
+      if (Array.isArray(data)) {
+        data = Buffer.concat(data);
       }
+      hooks.callHook("message", peer, new Message(data, peer));
     });
+    ws.on("error", (error: Error) => {
+      peers.delete(peer);
+      hooks.callHook("error", peer, new WSError(error));
+    });
+    ws.on("close", (code: number, reason: Buffer) => {
+      peers.delete(peer);
+      hooks.callHook("close", peer, {
+        code,
+        reason: reason?.toString(),
+      });
+    });
+  });
 
-    return {
-      ...adapterUtils(peers),
-      handleUpgrade: async (nodeReq, socket, head) => {
-        const request = new NodeReqProxy(nodeReq);
+  wss.on("headers", (outgoingHeaders, req) => {
+    const upgradeHeaders = (req as AugmentedReq)._upgradeHeaders;
+    if (upgradeHeaders) {
+      for (const [key, value] of new Headers(upgradeHeaders)) {
+        outgoingHeaders.push(`${key}: ${value}`);
+      }
+    }
+  });
 
-        const { upgradeHeaders, endResponse, context } =
-          await hooks.upgrade(request);
-        if (endResponse) {
-          return sendResponse(socket, endResponse);
-        }
+  return {
+    ...adapterUtils(peers),
+    handleUpgrade: async (nodeReq, socket, head) => {
+      const request = new NodeReqProxy(nodeReq);
 
-        (nodeReq as AugmentedReq)._request = request;
-        (nodeReq as AugmentedReq)._upgradeHeaders = upgradeHeaders;
-        (nodeReq as AugmentedReq)._context = context;
-        wss.handleUpgrade(nodeReq, socket, head, (ws) => {
-          wss.emit("connection", ws, nodeReq);
-        });
-      },
-      closeAll: (code, data) => {
-        for (const client of wss.clients) {
-          client.close(code, data);
-        }
-      },
-    };
-  },
-);
+      const { upgradeHeaders, endResponse, context } =
+        await hooks.upgrade(request);
+      if (endResponse) {
+        return sendResponse(socket, endResponse);
+      }
+
+      (nodeReq as AugmentedReq)._request = request;
+      (nodeReq as AugmentedReq)._upgradeHeaders = upgradeHeaders;
+      (nodeReq as AugmentedReq)._context = context;
+      wss.handleUpgrade(nodeReq, socket, head, (ws) => {
+        wss.emit("connection", ws, nodeReq);
+      });
+    },
+    closeAll: (code, data) => {
+      for (const client of wss.clients) {
+        client.close(code, data);
+      }
+    },
+  };
+};
+
+export default nodeAdapter;
 
 // --- peer ---
 
@@ -118,11 +118,11 @@ class NodePeer extends Peer<{
   nodeReq: IncomingMessage;
   ws: WebSocketT & { _peer?: NodePeer };
 }> {
-  get remoteAddress() {
+  override get remoteAddress() {
     return this._internal.nodeReq.socket?.remoteAddress;
   }
 
-  get context() {
+  override get context() {
     return (this._internal.nodeReq as AugmentedReq)._context;
   }
 
@@ -160,7 +160,7 @@ class NodePeer extends Peer<{
     this._internal.ws.close(code, data);
   }
 
-  terminate() {
+  override terminate() {
     this._internal.ws.terminate();
   }
 }

--- a/src/adapters/sse.ts
+++ b/src/adapters/sse.ts
@@ -1,7 +1,7 @@
-import type { AdapterOptions, AdapterInstance } from "../adapter.ts";
+import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import type * as web from "../../types/web.ts";
 import { toString } from "../utils.ts";
-import { defineWebSocketAdapter, adapterUtils } from "../adapter.ts";
+import { adapterUtils } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { Peer } from "../peer.ts";
@@ -19,7 +19,7 @@ export interface SSEOptions extends AdapterOptions {
 // --- adapter ---
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events
-export default defineWebSocketAdapter<SSEAdapter, SSEOptions>((opts = {}) => {
+const sseAdapter: Adapter<SSEAdapter, SSEOptions> = (opts = {}) => {
   const hooks = new AdapterHookable(opts);
   const peers = new Set<SSEPeer>();
   const peersMap = opts.bidir ? new Map<string, SSEPeer>() : undefined;
@@ -90,7 +90,9 @@ export default defineWebSocketAdapter<SSEAdapter, SSEOptions>((opts = {}) => {
       return new Response(peer._sseStream, { headers });
     },
   };
-});
+};
+
+export default sseAdapter;
 
 // --- peer ---
 

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,5 +1,6 @@
 import type { Peer } from "./peer.ts";
 import { randomUUID } from "uncrypto";
+import { kNodeInspect } from "./utils.ts";
 
 export class Message implements Partial<MessageEvent> {
   /** Access to the original [message event](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/message_event) if available. */
@@ -161,7 +162,7 @@ export class Message implements Partial<MessageEvent> {
   /**
    * Message data (value varies based on `peer.websocket.binaryType`).
    */
-  get data() {
+  get data(): unknown {
     switch (this.peer?.websocket?.binaryType as string) {
       case "arraybuffer": {
         return this.arrayBuffer();
@@ -188,15 +189,15 @@ export class Message implements Partial<MessageEvent> {
 
   // --- inspect ---
 
-  toString() {
+  toString(): string {
     return this.text();
   }
 
-  [Symbol.toPrimitive]() {
+  [Symbol.toPrimitive](): string {
     return this.text();
   }
 
-  [Symbol.for("nodejs.util.inspect.custom")]() {
+  [kNodeInspect](): { data: unknown } {
     return { data: this.rawData };
   }
 }

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -1,6 +1,7 @@
 import type * as web from "../types/web.ts";
 import { randomUUID } from "uncrypto";
 import type { UpgradeRequest } from "./hooks.ts";
+import { kNodeInspect } from "./utils.ts";
 
 export interface AdapterInternal {
   ws: unknown;
@@ -70,17 +71,17 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   abstract close(code?: number, reason?: string): void;
 
   /** Abruptly close the connection */
-  terminate() {
+  terminate(): void {
     this.close();
   }
 
   /** Subscribe to a topic */
-  subscribe(topic: string) {
+  subscribe(topic: string): void {
     this._topics.add(topic);
   }
 
   /** Unsubscribe from a topic */
-  unsubscribe(topic: string) {
+  unsubscribe(topic: string): void {
     this._topics.delete(topic);
   }
 
@@ -99,19 +100,19 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
 
   // --- inspect ---
 
-  toString() {
+  toString(): string {
     return this.id;
   }
 
-  [Symbol.toPrimitive]() {
+  [Symbol.toPrimitive](): string {
     return this.id;
   }
 
-  [Symbol.toStringTag]() {
+  [Symbol.toStringTag](): "WebSocket" {
     return "WebSocket";
   }
 
-  [Symbol.for("nodejs.util.inspect.custom")]() {
+  [kNodeInspect](): Record<string, unknown> {
     return Object.fromEntries(
       [
         ["id", this.id],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,7 +1,7 @@
 type BufferLike = string | Buffer | Uint8Array | ArrayBuffer;
 
 // https://nodejs.org/api/util.html#utilinspectcustom
-export const kNodeInspect: unique symbol = Symbol.for(
+export const kNodeInspect: unique symbol = /*#__PURE__*/ Symbol.for(
   "nodejs.util.inspect.custom",
 );
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,10 @@
 type BufferLike = string | Buffer | Uint8Array | ArrayBuffer;
 
+// https://nodejs.org/api/util.html#utilinspectcustom
+export const kNodeInspect: unique symbol = Symbol.for(
+  "nodejs.util.inspect.custom",
+);
+
 export function toBufferLike(val: any): BufferLike {
   if (val === undefined || val === null) {
     return "";

--- a/src/websocket/native.ts
+++ b/src/websocket/native.ts
@@ -1,1 +1,3 @@
-export default globalThis.WebSocket;
+const WebSocket: typeof globalThis.WebSocket = globalThis.WebSocket;
+
+export default WebSocket;

--- a/src/websocket/node.ts
+++ b/src/websocket/node.ts
@@ -1,3 +1,6 @@
 import { WebSocket as _WebSocket } from "ws";
 
-export default globalThis.WebSocket || _WebSocket;
+const Websocket: typeof globalThis.WebSocket =
+  globalThis.WebSocket || _WebSocket;
+
+export default Websocket;

--- a/test/adapters/uws.test.ts
+++ b/test/adapters/uws.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe } from "vitest";
 import { getRandomPort, waitForPort } from "get-port-please";
-import { App, TemplatedApp } from "uWebSockets.js";
+import { App, type TemplatedApp } from "uWebSockets.js";
 import uwsAdapter from "../../src/adapters/uws";
 import { createDemo } from "../fixture/_shared";
 import { wsTests } from "../tests";

--- a/test/fixture/_index.html.ts
+++ b/test/fixture/_index.html.ts
@@ -1,4 +1,4 @@
-export default function indexTemplate(opts: { sse?: boolean } = {}) {
+export default function indexTemplate(opts: { sse?: boolean } = {}): string {
   return /* html */ `
   <!doctype html>
   <html lang="en" data-theme="dark">

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -1,6 +1,10 @@
-import { Adapter, AdapterInstance, defineHooks } from "../../src/index.ts";
+import {
+  type Adapter,
+  type AdapterInstance,
+  defineHooks,
+} from "../../src/index.ts";
 
-export const getIndexHTML = (opts?: { sse?: boolean }) =>
+export const getIndexHTML = (opts?: { sse?: boolean }): Promise<string> =>
   import("./_index.html.ts").then((r) => r.default(opts));
 
 export function createDemo<T extends Adapter<any, any>>(

--- a/test/fixture/cloudflare-durable.ts
+++ b/test/fixture/cloudflare-durable.ts
@@ -32,20 +32,23 @@ export class $DurableObject extends DurableObject {
     ws.handleDurableInit(this, state, env);
   }
 
-  fetch(request: Request) {
+  override fetch(request: Request): Promise<Response> {
     return ws.handleDurableUpgrade(this, request);
   }
 
-  async webSocketMessage(client: WebSocket, message: ArrayBuffer | string) {
+  override async webSocketMessage(
+    client: WebSocket,
+    message: ArrayBuffer | string,
+  ): Promise<void> {
     return ws.handleDurableMessage(this, client, message);
   }
 
-  async webSocketClose(
+  override async webSocketClose(
     client: WebSocket,
     code: number,
     reason: string,
     wasClean: boolean,
-  ) {
+  ): Promise<void> {
     return ws.handleDurableClose(this, client, code, reason, wasClean);
   }
 }

--- a/test/fixture/cloudflare.ts
+++ b/test/fixture/cloudflare.ts
@@ -1,5 +1,8 @@
 // You can run this demo using `npm run play:cf` in repo
-import type { ExecutionContext } from "@cloudflare/workers-types";
+import type {
+  ExecutionContext,
+  Response as CFResponse,
+} from "@cloudflare/workers-types";
 import cloudflareAdapter from "../../src/adapters/cloudflare";
 import { createDemo, getIndexHTML, handleDemoRoutes } from "./_shared.ts";
 
@@ -10,7 +13,7 @@ export default {
     request: Request,
     env: Record<string, any>,
     context: ExecutionContext,
-  ) {
+  ): Promise<Response | CFResponse> {
     const response = handleDemoRoutes(ws, request);
     if (response) {
       return response;

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -7,7 +7,7 @@ export interface WSTestOpts {
   resHeaders?: boolean;
 }
 
-export function wsTests(getURL: () => string, opts: WSTestOpts) {
+export function wsTests(getURL: () => string, opts: WSTestOpts): void {
   test("http works", async () => {
     const response = await fetch(getURL().replace("ws", "http"));
     expect(response.status).toBe(200);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,14 +1,30 @@
 {
   "compilerOptions": {
     "target": "ESNext",
-    "module": "ESNext",
-    "moduleResolution": "Node",
+    "module": "preserve",
+    "moduleDetection": "force",
     "esModuleInterop": true,
-    "skipLibCheck": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
     "strict": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "noUncheckedIndexedAccess": true,
+    "forceConsistentCasingInFileNames": true,
     "allowImportingTsExtensions": true,
+    "noImplicitOverride": true,
     "noEmit": true,
-    "types": ["node", "@cloudflare/workers-types", "deno"]
+    "composite": false,
+    "isolatedDeclarations": false,
+    "types": [
+      "node",
+      "@cloudflare/workers-types",
+      "deno"
+    ]
   },
-  "include": ["src", "test"]
+  "include": [
+    "src",
+    "test",
+    "types"
+  ]
 }

--- a/types/ws.ts
+++ b/types/ws.ts
@@ -1,19 +1,19 @@
 /// <reference types="node" />
 
-import { EventEmitter } from "events";
-import {
+import type { EventEmitter } from "events";
+import type { Server as HTTPSServer } from "node:https";
+import type { Duplex, DuplexOptions } from "node:stream";
+import type { SecureContextOptions } from "node:tls";
+import type { URL } from "node:url";
+import type { ZlibOptions } from "node:zlib";
+import type {
   Agent,
   ClientRequest,
   ClientRequestArgs,
   IncomingMessage,
   OutgoingHttpHeaders,
   Server as HTTPServer,
-} from "http";
-import { Server as HTTPSServer } from "https";
-import { Duplex, DuplexOptions } from "stream";
-import { SecureContextOptions } from "tls";
-import { URL } from "url";
-import { ZlibOptions } from "zlib";
+} from "node:http";
 
 // can not get all overload of BufferConstructor['from'], need to copy all it's first arguments here
 // https://github.com/microsoft/TypeScript/issues/32164


### PR DESCRIPTION
This PR improves overall type safety with explicit declarations to avoid issues like #127 

`isolatedDeclarations` is now passing for entire codebase however (sadly) we need to disable since **two** usages of `unique symbol` in class props cannot be fixed or avoided (ts limitation) 