### PR TITLE
fix: define `request.context` as read only

### DIFF
--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -47,7 +47,15 @@ export class AdapterHookable {
     endResponse?: Response;
     context: Peer["context"];
   }> {
-    const context = (request.context ??= {});
+    let context = request.context;
+    if (!context) {
+      context = {};
+      Object.defineProperty(request, "context", {
+        enumerable: true,
+        value: context,
+      });
+    }
+
     try {
       const res = await this.callHook(
         "upgrade",

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -41,7 +41,7 @@ export class AdapterHookable {
   }
 
   async upgrade(
-    request: UpgradeRequest & { context?: Peer["context"] },
+    request: UpgradeRequest & { readonly context?: Peer["context"] },
   ): Promise<{
     upgradeHeaders?: HeadersInit;
     endResponse?: Response;


### PR DESCRIPTION
Resolves #115

Marks `request.context` (in `upgrade` hook) both by type using `readonly` and in runtime using `Object.defineProperty` as read only