### PR TITLE
fix: change Node adapter's `handleUpgrade` function return type to a Promise

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -25,7 +25,7 @@ type AugmentedReq = IncomingMessage & {
 };
 
 export interface NodeAdapter extends AdapterInstance {
-  handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): void;
+  handleUpgrade(req: IncomingMessage, socket: Duplex, head: Buffer): Promise<void>;
   closeAll: (code?: number, data?: string | Buffer) => void;
 }
 


### PR DESCRIPTION
fixes https://github.com/unjs/crossws/issues/135

This PR changes the return type of the Node adapter's `handleUpgrade` function from `void` to `Promise<void>` since the actual function has been marked with the `async` keyword.

<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
