### PR TITLE
refactor!: remove uncrypto dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,9 +83,6 @@
   "resolutions": {
     "crossws": "workspace:*"
   },
-  "dependencies": {
-    "uncrypto": "^0.1.3"
-  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20250204.0",
     "@types/bun": "^1.2.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,10 +10,6 @@ overrides:
 importers:
 
   .:
-    dependencies:
-      uncrypto:
-        specifier: ^0.1.3
-        version: 0.1.3
     devDependencies:
       '@cloudflare/workers-types':
         specifier: ^4.20250204.0

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,5 +1,5 @@
 import type { Peer } from "./peer.ts";
-import { randomUUID } from "uncrypto";
+import { randomUUID } from "node:crypto";
 import { kNodeInspect } from "./utils.ts";
 
 export class Message implements Partial<MessageEvent> {

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -1,5 +1,5 @@
 import type * as web from "../types/web.ts";
-import { randomUUID } from "uncrypto";
+import { randomUUID } from "node:crypto";
 import type { UpgradeRequest } from "./hooks.ts";
 import { kNodeInspect } from "./utils.ts";
 


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
I believe these APIs are only called on the server, so there's no need to use `uncrypto`'s support for browser/server-independent APIs. We don't use `uncrypto` anywhere else in SvelteKit, so it'd be nice for us to avoid the extra dependency if not required.