### PR TITLE
test(node): add regression test for `EADDRINUSE` handling

### DIFF
--- a/test/unit.test.ts
+++ b/test/unit.test.ts
@@ -1,5 +1,9 @@
+import { createServer } from "node:http";
+import { once } from "node:events";
+import { getRandomPort } from "get-port-please";
 import { test, expect } from "vitest";
-import { toBufferLike } from "../src/utils";
+import { serve } from "../src/server/node.ts";
+import { toBufferLike } from "../src/utils.ts";
 
 test("toBufferLike", () => {
   expect(toBufferLike(undefined)).toBe("");
@@ -13,4 +17,18 @@ test("toBufferLike", () => {
     new Uint8Array([1, 2, 3]),
   );
   expect(toBufferLike(new ArrayBuffer(3))).toEqual(new ArrayBuffer(3));
+});
+
+test("ready() rejects on EADDRINUSE", async () => {
+  const port = await getRandomPort("localhost");
+  const blocker = createServer().listen(port, "127.0.0.1");
+  await once(blocker, "listening");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => new Response("ok"),
+    websocket: {},
+  });
+  await expect(server.ready()).rejects.toMatchObject({ code: "EADDRINUSE" });
+  blocker.close();
 });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

## Summary

Close #182

I tried my best to include the reproducible worker code, if you wish to have dedicated Node.js process for this to be reproduced and checked, please tell me.

This error was long existed for `srvx` too, we had to https://github.com/moeru-ai/airi/blob/main/patches/srvx.patch patch the `error` handler all the way down, I found that recently `crossws` somehow thrown this error too (probably because we just bump-ed the version).

> I will create another PR to `srvx` to fix this.

I am not sure how to design and handle the `Promise` return for server.serve, please review it and suggest me if needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added test coverage for server startup behavior when the configured port is already in use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->