### PR TITLE
feat: add `createWebSocketProxy` util

### DIFF
--- a/docs/1.guide/7.proxy.md
+++ b/docs/1.guide/7.proxy.md
@@ -8,6 +8,9 @@ icon: tabler:arrows-exchange
 
 crossws ships a small helper that returns a set of ready-made hooks which proxy every peer to an upstream WebSocket server. Use it to put crossws in front of an existing backend, split traffic across services, or bridge protocols between runtimes.
 
+> [!NOTE]
+> The proxy uses the global [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) constructor to dial the upstream, which is available on Node.js ≥ 22, Bun, Deno, Cloudflare Workers, and browsers. On older Node versions, provide a `WebSocket` polyfill on `globalThis`.
+
 ## Usage
 
 `createWebSocketProxy()` returns a `Partial<Hooks>` object that you can pass straight to any crossws adapter.
@@ -55,6 +58,9 @@ createWebSocketProxy({
 });
 ```
 
+> [!WARNING]
+> The proxy commits to a subprotocol in the upgrade response before the upstream connection is established. If the upstream ultimately picks a different subprotocol (or rejects), the client will still see the one the proxy promised. Only keep `forwardProtocol` enabled when the upstream is known to accept the same subprotocols the client negotiates.
+
 ## Combining with custom hooks
 
 `createWebSocketProxy()` returns a plain hooks object, so you can spread it and override individual hooks — for example, to authenticate the upgrade request before proxying:
@@ -83,5 +89,7 @@ Accepts either a target URL (`string` or `URL`), a resolver function, or an opti
 
 - **`target`** — `string | URL | (peer: Peer) => string | URL`. The upstream WebSocket URL, or a function that resolves it per peer.
 - **`forwardProtocol`** — `boolean` (default `true`). When enabled, the client's `sec-websocket-protocol` header is forwarded to the upstream and echoed back in the upgrade response.
+- **`maxBufferSize`** — `number` (default `1048576`, i.e. 1 MiB). Maximum number of bytes buffered per peer while the upstream is still connecting. When exceeded, the peer is closed with code `1009` (Message Too Big). Set to `0` to disable.
+- **`connectTimeout`** — `number` (default `10000`). Milliseconds to wait for the upstream WebSocket handshake to complete. If exceeded, the peer is closed with code `1011`. Set to `0` to disable.
 
 Returns a `Partial<Hooks>` object containing `upgrade`, `open`, `message`, `close`, and `error` hooks.

--- a/docs/1.guide/7.proxy.md
+++ b/docs/1.guide/7.proxy.md
@@ -1,0 +1,87 @@
+---
+icon: tabler:arrows-exchange
+---
+
+# WebSocket Proxy
+
+> Forward incoming WebSocket connections to an upstream `ws://` or `wss://` target.
+
+crossws ships a small helper that returns a set of ready-made hooks which proxy every peer to an upstream WebSocket server. Use it to put crossws in front of an existing backend, split traffic across services, or bridge protocols between runtimes.
+
+## Usage
+
+`createWebSocketProxy()` returns a `Partial<Hooks>` object that you can pass straight to any crossws adapter.
+
+```ts
+// https://crossws.h3.dev/adapters
+import crossws from "crossws/adapters/<adapter>";
+import { createWebSocketProxy } from "crossws";
+
+const websocket = crossws({
+  hooks: createWebSocketProxy("wss://echo.websocket.org"),
+});
+```
+
+Every incoming peer opens a matching upstream connection. Text and binary messages are forwarded in both directions, and close/error events are propagated to the client.
+
+> [!TIP]
+> Messages sent by the client before the upstream connection is ready are buffered and flushed as soon as the upstream is open.
+
+## Dynamic target
+
+Pass a function to resolve the upstream URL from the incoming [`Peer`](/guide/peer) — useful for routing based on request URL, headers, or authenticated context.
+
+```ts
+import { createWebSocketProxy } from "crossws";
+
+const hooks = createWebSocketProxy({
+  target: (peer) => {
+    const { pathname } = new URL(peer.request.url);
+    return pathname.startsWith("/admin")
+      ? "wss://admin.internal/ws"
+      : "wss://public.internal/ws";
+  },
+});
+```
+
+## Subprotocol negotiation
+
+By default, the proxy forwards the client's `sec-websocket-protocol` header to the upstream and echoes the first requested subprotocol back in the upgrade response so the client handshake succeeds. Disable this if you want to negotiate subprotocols yourself:
+
+```ts
+createWebSocketProxy({
+  target: "wss://backend.example.com",
+  forwardProtocol: false,
+});
+```
+
+## Combining with custom hooks
+
+`createWebSocketProxy()` returns a plain hooks object, so you can spread it and override individual hooks — for example, to authenticate the upgrade request before proxying:
+
+```ts
+import { createWebSocketProxy } from "crossws";
+
+const proxyHooks = createWebSocketProxy("wss://backend.example.com");
+
+const hooks = {
+  ...proxyHooks,
+  upgrade(req) {
+    if (!req.headers.get("authorization")) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+    return proxyHooks.upgrade?.(req);
+  },
+};
+```
+
+## API
+
+### `createWebSocketProxy(target)`
+
+Accepts either a target URL (`string` or `URL`), a resolver function, or an options object:
+
+- **`target`** — `string | URL | (peer: Peer) => string | URL`. The upstream WebSocket URL, or a function that resolves it per peer.
+- **`forwardProtocol`** — `boolean` (default `true`). When enabled, the client's `sec-websocket-protocol` header is forwarded to the upstream and echoed back in the upgrade response.
+
+Returns a `Partial<Hooks>` object containing `upgrade`, `open`, `message`, `close`, and `error` hooks.

--- a/docs/1.guide/7.proxy.md
+++ b/docs/1.guide/7.proxy.md
@@ -9,7 +9,7 @@ icon: tabler:arrows-exchange
 crossws ships a small helper that returns a set of ready-made hooks which proxy every peer to an upstream WebSocket server. Use it to put crossws in front of an existing backend, split traffic across services, or bridge protocols between runtimes.
 
 > [!NOTE]
-> The proxy uses the global [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) constructor to dial the upstream, which is available on Node.js ≥ 22, Bun, Deno, Cloudflare Workers, and browsers. On older Node versions, provide a `WebSocket` polyfill on `globalThis`.
+> The proxy uses the global [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) constructor to dial the upstream, which is available on Node.js ≥ 22, Bun, Deno, Cloudflare Workers, and browsers. On older Node versions, pass a custom constructor via the [`WebSocket` option](#custom-websocket-constructor) or install a polyfill on `globalThis`.
 
 ## Usage
 
@@ -61,6 +61,20 @@ createWebSocketProxy({
 > [!WARNING]
 > The proxy commits to a subprotocol in the upgrade response before the upstream connection is established. If the upstream ultimately picks a different subprotocol (or rejects), the client will still see the one the proxy promised. Only keep `forwardProtocol` enabled when the upstream is known to accept the same subprotocols the client negotiates.
 
+## Custom WebSocket constructor
+
+Pass a `WebSocket` constructor via options to override the global — useful on Node.js < 22, to plug in a different client implementation, or to stub the upstream in tests.
+
+```ts
+import { WebSocket } from "ws";
+import { createWebSocketProxy } from "crossws";
+
+const hooks = createWebSocketProxy({
+  target: "wss://backend.example.com",
+  WebSocket: WebSocket as unknown as typeof globalThis.WebSocket,
+});
+```
+
 ## Combining with custom hooks
 
 `createWebSocketProxy()` returns a plain hooks object, so you can spread it and override individual hooks — for example, to authenticate the upgrade request before proxying:
@@ -91,5 +105,6 @@ Accepts either a target URL (`string` or `URL`), a resolver function, or an opti
 - **`forwardProtocol`** — `boolean` (default `true`). When enabled, the client's `sec-websocket-protocol` header is forwarded to the upstream and echoed back in the upgrade response.
 - **`maxBufferSize`** — `number` (default `1048576`, i.e. 1 MiB). Maximum number of bytes buffered per peer while the upstream is still connecting. When exceeded, the peer is closed with code `1009` (Message Too Big). Set to `0` to disable.
 - **`connectTimeout`** — `number` (default `10000`). Milliseconds to wait for the upstream WebSocket handshake to complete. If exceeded, the peer is closed with code `1011`. Set to `0` to disable.
+- **`WebSocket`** — `typeof WebSocket` (default `globalThis.WebSocket`). Custom `WebSocket` constructor used to dial the upstream. Falls back to the global when omitted; throws at setup time if neither is available.
 
 Returns a `Partial<Hooks>` object containing `upgrade`, `open`, `message`, `close`, and `error` hooks.

--- a/docs/1.guide/7.proxy.md
+++ b/docs/1.guide/7.proxy.md
@@ -30,6 +30,34 @@ Every incoming peer opens a matching upstream connection. Text and binary messag
 > [!TIP]
 > Messages sent by the client before the upstream connection is ready are buffered and flushed as soon as the upstream is open.
 
+> [!CAUTION]
+> **The default proxy is an open relay.** It accepts every incoming connection and forwards it to the configured upstream without any authorization check. Always combine it with an [`upgrade` hook](#authentication) when the upstream is not itself publicly accessible — otherwise anyone who can reach the proxy can reach the upstream.
+
+## Authentication
+
+`createWebSocketProxy()` returns a plain hooks object, so you can spread it and override individual hooks. Authenticate the upgrade request before proxying by wrapping the proxy's `upgrade` hook:
+
+```ts
+import { createWebSocketProxy } from "crossws";
+
+const proxyHooks = createWebSocketProxy("wss://backend.example.com");
+
+const hooks = {
+  ...proxyHooks,
+  async upgrade(req) {
+    const token = req.headers.get("authorization");
+    if (!(await isValidToken(token))) {
+      return new Response("Unauthorized", { status: 401 });
+    }
+    // Delegate to the proxy's own `upgrade` so subprotocol echoing still works.
+    return proxyHooks.upgrade?.(req);
+  },
+};
+```
+
+> [!NOTE]
+> The WHATWG `WebSocket` constructor cannot forward cookies, `Authorization`, or `Origin` to the upstream, so upstream identity checks relying on those headers will silently fail. Authenticate at the proxy, or pass a custom `WebSocket` client and use the [`headers` option](#forwarding-headers) to propagate identity.
+
 ## Dynamic target
 
 Pass a function to resolve the upstream URL from the incoming [`Peer`](/guide/peer) — useful for routing based on request URL, headers, or authenticated context.
@@ -46,6 +74,9 @@ const hooks = createWebSocketProxy({
   },
 });
 ```
+
+> [!WARNING]
+> **SSRF risk.** A dynamic `target` resolver is a trust boundary. Never interpolate untrusted input (query strings, headers, path segments a client controls) directly into the returned URL — a naive resolver turns the proxy into an SSRF primitive that can dial `ws://127.0.0.1`, `ws://169.254.169.254`, or any reachable internal service. Always resolve against a hard-coded allowlist of hosts you control.
 
 ## Subprotocol negotiation
 
@@ -75,25 +106,40 @@ const hooks = createWebSocketProxy({
 });
 ```
 
-## Combining with custom hooks
+### Unix domain sockets
 
-`createWebSocketProxy()` returns a plain hooks object, so you can spread it and override individual hooks — for example, to authenticate the upgrade request before proxying:
+The proxy does not enforce any scheme allowlist — whatever the configured `WebSocket` constructor accepts is accepted. For example, the [`ws`](https://github.com/websockets/ws) package supports Unix domain sockets via its `ws+unix:` scheme:
 
 ```ts
+import { WebSocket } from "ws";
 import { createWebSocketProxy } from "crossws";
 
-const proxyHooks = createWebSocketProxy("wss://backend.example.com");
-
-const hooks = {
-  ...proxyHooks,
-  upgrade(req) {
-    if (!req.headers.get("authorization")) {
-      return new Response("Unauthorized", { status: 401 });
-    }
-    return proxyHooks.upgrade?.(req);
-  },
-};
+const hooks = createWebSocketProxy({
+  target: "ws+unix:/var/run/backend.sock:/chat",
+  WebSocket: WebSocket as unknown as typeof globalThis.WebSocket,
+});
 ```
+
+## Forwarding headers
+
+Passing a `headers` option attaches extra headers to the upstream handshake. This is the usual way to forward identity (`cookie`, `authorization`, `origin`) or inject a shared secret to the upstream.
+
+```ts
+import { WebSocket } from "ws";
+import { createWebSocketProxy } from "crossws";
+
+const hooks = createWebSocketProxy({
+  target: "wss://backend.example.com",
+  WebSocket: WebSocket as unknown as typeof globalThis.WebSocket,
+  headers: (peer) => ({
+    cookie: peer.request.headers.get("cookie") ?? "",
+    "x-forwarded-for": peer.remoteAddress ?? "",
+  }),
+});
+```
+
+> [!IMPORTANT]
+> The WHATWG global `WebSocket` constructor does **not** accept custom headers. `headers` is only honored when a `WebSocket` constructor that takes a third options argument is passed via the [`WebSocket` option](#custom-websocket-constructor) — e.g. [`ws`](https://github.com/websockets/ws) or [`undici`](https://undici.nodejs.org). With the global constructor the option is silently ignored.
 
 ## API
 
@@ -101,9 +147,10 @@ const hooks = {
 
 Accepts either a target URL (`string` or `URL`), a resolver function, or an options object:
 
-- **`target`** — `string | URL | (peer: Peer) => string | URL`. The upstream WebSocket URL, or a function that resolves it per peer.
-- **`forwardProtocol`** — `boolean` (default `true`). When enabled, the client's `sec-websocket-protocol` header is forwarded to the upstream and echoed back in the upgrade response.
-- **`maxBufferSize`** — `number` (default `1048576`, i.e. 1 MiB). Maximum number of bytes buffered per peer while the upstream is still connecting. When exceeded, the peer is closed with code `1009` (Message Too Big). Set to `0` to disable.
+- **`target`** — `string | URL | (peer: Peer) => string | URL`. The upstream WebSocket URL, or a function that resolves it per peer. The proxy does not enforce a scheme allowlist; any URL the configured `WebSocket` constructor accepts (including `ws+unix:` with `ws`) works. See the [SSRF warning](#dynamic-target) before using a dynamic resolver.
+- **`forwardProtocol`** — `boolean` (default `true`). When enabled, the client's `sec-websocket-protocol` header is forwarded to the upstream and echoed back in the upgrade response. Values that are not valid RFC 7230 tokens are dropped.
+- **`headers`** — `HeadersInit | (peer: Peer) => HeadersInit`. Extra headers to send on the upstream handshake. Only honored when a custom `WebSocket` constructor that accepts a third options argument is supplied — the WHATWG global ignores it.
+- **`maxBufferSize`** — `number` (default `1048576`, i.e. 1 MiB). Maximum number of bytes buffered per peer while the upstream is still connecting. String frames are accounted at their UTF-8 worst case (3 bytes per UTF-16 code unit) to avoid undercounting multi-byte content. When exceeded, the peer is closed with code `1009` (Message Too Big). Set to `0` to disable.
 - **`connectTimeout`** — `number` (default `10000`). Milliseconds to wait for the upstream WebSocket handshake to complete. If exceeded, the peer is closed with code `1011`. Set to `0` to disable.
 - **`WebSocket`** — `typeof WebSocket` (default `globalThis.WebSocket`). Custom `WebSocket` constructor used to dial the upstream. Falls back to the global when omitted; throws at setup time if neither is available.
 

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -74,9 +74,12 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
     });
     peers.add(peer);
     hooks.callHook("open", peer); // ws is already open
-    ws.on("message", (data: unknown) => {
+    ws.on("message", (data: unknown, isBinary: boolean) => {
       if (Array.isArray(data)) {
         data = Buffer.concat(data);
+      }
+      if (!isBinary && Buffer.isBuffer(data)) {
+        data = data.toString("utf8");
       }
       hooks.callHook("message", peer, new Message(data, peer));
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,4 +18,8 @@ export type { WSError } from "./error.ts";
 // Server
 export type { ServerWithWSOptions, WSOptions } from "./server/_types.ts";
 
+// Proxy
+export { createWebSocketProxy } from "./proxy.ts";
+export type { WebSocketProxyOptions } from "./proxy.ts";
+
 // Removed from 0.2.x: createCrossWS, Caller, WSRequest, CrossWS

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -94,8 +94,7 @@ export function createWebSocketProxy(
       };
       upstreams.set(peer.id, state);
 
-      const timeoutMs =
-        options.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT;
+      const timeoutMs = options.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT;
       if (timeoutMs > 0) {
         state.timeout = setTimeout(() => {
           if (upstreams.get(peer.id) !== state || state.open) return;

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,13 @@
 import type { Hooks } from "./hooks.ts";
 import type { Peer } from "./peer.ts";
 
+// 1 MiB — generous enough for typical chatty clients while bounding memory
+// consumption of stalled-upstream peers.
+const DEFAULT_MAX_BUFFER_SIZE = 1024 * 1024;
+
+// 10 seconds — aligns with common reverse-proxy defaults (nginx, haproxy).
+const DEFAULT_CONNECT_TIMEOUT = 10_000;
+
 export interface WebSocketProxyOptions {
   /**
    * Target WebSocket URL to proxy to (`ws://` or `wss://`).
@@ -16,6 +23,24 @@ export interface WebSocketProxyOptions {
    * @default true
    */
   forwardProtocol?: boolean;
+
+  /**
+   * Maximum number of bytes buffered per peer while the upstream connection
+   * is still opening. If exceeded, the peer is closed with code `1009`
+   * (Message Too Big). Set to `0` to disable the limit.
+   *
+   * @default 1048576 (1 MiB)
+   */
+  maxBufferSize?: number;
+
+  /**
+   * Milliseconds to wait for the upstream WebSocket handshake to complete.
+   * If the upstream does not open within the timeout, the peer is closed
+   * with code `1011`. Set to `0` to disable the timeout.
+   *
+   * @default 10000
+   */
+  connectTimeout?: number;
 }
 
 /**
@@ -60,15 +85,33 @@ export function createWebSocketProxy(
       const ws = new WebSocket(url, protocols);
       ws.binaryType = "arraybuffer";
 
-      const state: UpstreamState = { ws, buffer: [], open: false };
+      const state: UpstreamState = {
+        ws,
+        buffer: [],
+        bufferSize: 0,
+        open: false,
+        timeout: undefined,
+      };
       upstreams.set(peer.id, state);
 
+      const timeoutMs =
+        options.connectTimeout ?? DEFAULT_CONNECT_TIMEOUT;
+      if (timeoutMs > 0) {
+        state.timeout = setTimeout(() => {
+          if (upstreams.get(peer.id) !== state || state.open) return;
+          _cleanupState(upstreams, peer.id, state);
+          _safeClose(peer, 1011, "Upstream connect timeout");
+        }, timeoutMs);
+      }
+
       ws.addEventListener("open", () => {
+        _clearTimeout(state);
         state.open = true;
         for (const data of state.buffer) {
-          ws.send(data as Parameters<WebSocket["send"]>[0]);
+          ws.send(data);
         }
         state.buffer.length = 0;
+        state.bufferSize = 0;
       });
 
       ws.addEventListener("message", (event) => {
@@ -76,12 +119,17 @@ export function createWebSocketProxy(
       });
 
       ws.addEventListener("close", (event) => {
-        upstreams.delete(peer.id);
-        _safeClose(peer, event.code, event.reason);
+        // Ignore if the state was already cleaned up (e.g. proxy-initiated
+        // close or buffer limit); we only propagate unsolicited upstream
+        // closures to the client.
+        if (upstreams.get(peer.id) !== state) return;
+        _cleanupState(upstreams, peer.id, state);
+        _safeClose(peer, _remapCloseCode(event.code), event.reason);
       });
 
       ws.addEventListener("error", () => {
-        upstreams.delete(peer.id);
+        if (upstreams.get(peer.id) !== state) return;
+        _cleanupState(upstreams, peer.id, state);
         _safeClose(peer, 1011, "Upstream error");
       });
     },
@@ -94,18 +142,27 @@ export function createWebSocketProxy(
           ? message.rawData
           : message.uint8Array();
       if (state.open) {
-        state.ws.send(data as Parameters<WebSocket["send"]>[0]);
-      } else {
-        state.buffer.push(data);
+        state.ws.send(data);
+        return;
       }
+      const size = typeof data === "string" ? data.length : data.byteLength;
+      const limit = options.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
+      if (limit > 0 && state.bufferSize + size > limit) {
+        _cleanupState(upstreams, peer.id, state);
+        _safeClose(peer, 1009, "Proxy buffer limit exceeded");
+        return;
+      }
+      state.buffer.push(data);
+      state.bufferSize += size;
     },
 
     close(peer, details) {
       const state = upstreams.get(peer.id);
       if (!state) return;
+      _clearTimeout(state);
       upstreams.delete(peer.id);
       try {
-        state.ws.close(details.code, details.reason);
+        state.ws.close(_remapCloseCode(details.code), details.reason);
       } catch {
         // ignore invalid code/reason
       }
@@ -114,9 +171,10 @@ export function createWebSocketProxy(
     error(peer) {
       const state = upstreams.get(peer.id);
       if (!state) return;
+      _clearTimeout(state);
       upstreams.delete(peer.id);
       try {
-        state.ws.close();
+        state.ws.close(1011, "Peer error");
       } catch {
         // ignore
       }
@@ -128,8 +186,31 @@ export function createWebSocketProxy(
 
 interface UpstreamState {
   ws: WebSocket;
-  buffer: unknown[];
+  buffer: Array<string | Uint8Array>;
+  bufferSize: number;
   open: boolean;
+  timeout: ReturnType<typeof setTimeout> | undefined;
+}
+
+function _cleanupState(
+  upstreams: Map<string, UpstreamState>,
+  id: string,
+  state: UpstreamState,
+): void {
+  _clearTimeout(state);
+  upstreams.delete(id);
+  try {
+    state.ws.close();
+  } catch {
+    // ignore
+  }
+}
+
+function _clearTimeout(state: UpstreamState): void {
+  if (state.timeout !== undefined) {
+    clearTimeout(state.timeout);
+    state.timeout = undefined;
+  }
 }
 
 function _resolveTarget(
@@ -159,4 +240,13 @@ function _safeClose(peer: Peer, code?: number, reason?: string): void {
   } catch {
     // ignore
   }
+}
+
+// Reserved codes must never appear in an outbound close frame.
+// 1005 (no status), 1006 (abnormal), 1015 (TLS failure) get remapped.
+function _remapCloseCode(code?: number): number | undefined {
+  if (code === undefined) return undefined;
+  if (code === 1005) return 1000;
+  if (code === 1006 || code === 1015) return 1011;
+  return code;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -115,7 +115,7 @@ export function createWebSocketProxy(
       });
 
       ws.addEventListener("message", (event) => {
-        peer.send(event.data);
+        _safeSend(peer, event.data);
       });
 
       ws.addEventListener("close", (event) => {
@@ -162,7 +162,10 @@ export function createWebSocketProxy(
       _clearTimeout(state);
       upstreams.delete(peer.id);
       try {
-        state.ws.close(_remapCloseCode(details.code), details.reason);
+        state.ws.close(
+          _remapCloseCode(details.code),
+          _truncateReason(details.reason),
+        );
       } catch {
         // ignore invalid code/reason
       }
@@ -236,10 +239,28 @@ function _resolveProtocols(
 
 function _safeClose(peer: Peer, code?: number, reason?: string): void {
   try {
-    peer.close(code, reason);
+    peer.close(code, _truncateReason(reason));
   } catch {
     // ignore
   }
+}
+
+function _safeSend(peer: Peer, data: unknown): void {
+  try {
+    peer.send(data);
+  } catch {
+    // ignore — peer may already be closed
+  }
+}
+
+// WebSocket close frames cap the reason at 123 UTF-8 bytes.
+function _truncateReason(reason?: string): string | undefined {
+  if (!reason) return reason;
+  const bytes = new TextEncoder().encode(reason);
+  if (bytes.length <= 123) return reason;
+  return new TextDecoder("utf-8", { fatal: false }).decode(
+    bytes.subarray(0, 123),
+  );
 }
 
 // Reserved codes must never appear in an outbound close frame.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -41,6 +41,16 @@ export interface WebSocketProxyOptions {
    * @default 10000
    */
   connectTimeout?: number;
+
+  /**
+   * Custom `WebSocket` constructor used to dial the upstream. Useful when
+   * the runtime does not expose a global `WebSocket` (Node.js < 22) or
+   * when you want to use a different client implementation (e.g. `ws`,
+   * `undici`, a mock for tests).
+   *
+   * @default globalThis.WebSocket
+   */
+  WebSocket?: typeof WebSocket;
 }
 
 /**
@@ -64,6 +74,13 @@ export function createWebSocketProxy(
       ? { target }
       : target;
 
+  const WebSocketCtor = options.WebSocket ?? globalThis.WebSocket;
+  if (typeof WebSocketCtor !== "function") {
+    throw new TypeError(
+      "createWebSocketProxy requires a `WebSocket` constructor. Pass one via the `WebSocket` option, or use a runtime that provides a global `WebSocket` (Node.js >= 22, Bun, Deno, Cloudflare Workers, browsers).",
+    );
+  }
+
   const upstreams = new Map<string, UpstreamState>();
 
   return {
@@ -82,7 +99,7 @@ export function createWebSocketProxy(
       const url = _resolveTarget(options.target, peer);
       const protocols = _resolveProtocols(peer, options.forwardProtocol);
 
-      const ws = new WebSocket(url, protocols);
+      const ws = new WebSocketCtor(url, protocols);
       ws.binaryType = "arraybuffer";
 
       const state: UpstreamState = {
@@ -123,7 +140,7 @@ export function createWebSocketProxy(
         // closures to the client.
         if (upstreams.get(peer.id) !== state) return;
         _cleanupState(upstreams, peer.id, state);
-        _safeClose(peer, _remapCloseCode(event.code), event.reason);
+        _safeClose(peer, _remapIncomingCode(event.code), event.reason);
       });
 
       ws.addEventListener("error", () => {
@@ -136,22 +153,29 @@ export function createWebSocketProxy(
     message(peer, message) {
       const state = upstreams.get(peer.id);
       if (!state) return;
-      const data =
+      const raw =
         typeof message.rawData === "string"
           ? message.rawData
           : message.uint8Array();
       if (state.open) {
-        state.ws.send(data);
+        try {
+          state.ws.send(raw);
+        } catch {
+          // upstream may have transitioned to CLOSING between the check and send
+        }
         return;
       }
-      const size = typeof data === "string" ? data.length : data.byteLength;
+      const size = typeof raw === "string" ? raw.length : raw.byteLength;
       const limit = options.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
       if (limit > 0 && state.bufferSize + size > limit) {
         _cleanupState(upstreams, peer.id, state);
         _safeClose(peer, 1009, "Proxy buffer limit exceeded");
         return;
       }
-      state.buffer.push(data);
+      // Copy binary views before buffering: the adapter may own the backing
+      // memory (e.g. Node's `ws` reuses Buffers in some paths) and the buffer
+      // may be flushed asynchronously once the upstream is open.
+      state.buffer.push(typeof raw === "string" ? raw : Uint8Array.from(raw));
       state.bufferSize += size;
     },
 
@@ -162,7 +186,7 @@ export function createWebSocketProxy(
       upstreams.delete(peer.id);
       try {
         state.ws.close(
-          _remapCloseCode(details.code),
+          _normalizeOutgoingCode(details.code),
           _truncateReason(details.reason),
         );
       } catch {
@@ -262,11 +286,25 @@ function _truncateReason(reason?: string): string | undefined {
   );
 }
 
-// Reserved codes must never appear in an outbound close frame.
-// 1005 (no status), 1006 (abnormal), 1015 (TLS failure) get remapped.
-function _remapCloseCode(code?: number): number | undefined {
+// Upstream close event → peer.close. Reserved pseudo-codes (1005/1006/1015)
+// must never appear on the wire, so they are rewritten. Everything else is
+// forwarded as-is; server-side peers can use the full 1000-4999 range.
+/** @internal exported for tests */
+export function _remapIncomingCode(code?: number): number | undefined {
   if (code === undefined) return undefined;
   if (code === 1005) return 1000;
   if (code === 1006 || code === 1015) return 1011;
   return code;
+}
+
+// Peer close → upstream `state.ws.close`. The upstream is a client-side
+// WebSocket, and WHATWG restricts close() to 1000 or 3000-4999 — anything
+// else (1001 going-away, 1008 policy, etc.) throws InvalidAccessError.
+// Normalize to 1000 so we don't silently fail to close the upstream.
+/** @internal exported for tests */
+export function _normalizeOutgoingCode(code?: number): number | undefined {
+  if (code === undefined) return undefined;
+  if (code === 1000) return 1000;
+  if (code >= 3000 && code <= 4999) return code;
+  return 1000;
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -147,7 +147,10 @@ function _resolveProtocols(
   if (forwardProtocol === false) return;
   const header = peer.request?.headers.get("sec-websocket-protocol");
   if (!header) return;
-  return header.split(",").map((p) => p.trim()).filter(Boolean);
+  return header
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
 }
 
 function _safeClose(peer: Peer, code?: number, reason?: string): void {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,0 +1,159 @@
+import type { Hooks } from "./hooks.ts";
+import type { Peer } from "./peer.ts";
+
+export interface WebSocketProxyOptions {
+  /**
+   * Target WebSocket URL to proxy to (`ws://` or `wss://`).
+   *
+   * Can be a static string/URL or a function that resolves the target dynamically
+   * based on the incoming {@link Peer}.
+   */
+  target: string | URL | ((peer: Peer) => string | URL);
+
+  /**
+   * Forward the client's `sec-websocket-protocol` header to the upstream.
+   *
+   * @default true
+   */
+  forwardProtocol?: boolean;
+}
+
+/**
+ * Create a set of crossws hooks that proxy incoming WebSocket connections
+ * to an upstream `ws://` or `wss://` target.
+ *
+ * @example
+ * ```ts
+ * import { createWebSocketProxy } from "crossws";
+ *
+ * const hooks = createWebSocketProxy("wss://echo.websocket.org");
+ * ```
+ */
+export function createWebSocketProxy(
+  target: WebSocketProxyOptions["target"] | WebSocketProxyOptions,
+): Partial<Hooks> {
+  const options: WebSocketProxyOptions =
+    typeof target === "string" ||
+    target instanceof URL ||
+    typeof target === "function"
+      ? { target }
+      : target;
+
+  const upstreams = new Map<string, UpstreamState>();
+
+  return {
+    upgrade(request) {
+      const reqProtocol = request.headers.get("sec-websocket-protocol");
+      if (options.forwardProtocol === false || !reqProtocol) {
+        return;
+      }
+      // Accept the first requested subprotocol so the upgrade handshake
+      // echoes a value the client expects. Upstream must support it too.
+      const accepted = reqProtocol.split(",")[0]!.trim();
+      return { headers: { "sec-websocket-protocol": accepted } };
+    },
+
+    open(peer) {
+      const url = _resolveTarget(options.target, peer);
+      const protocols = _resolveProtocols(peer, options.forwardProtocol);
+
+      const ws = new WebSocket(url, protocols);
+      ws.binaryType = "arraybuffer";
+
+      const state: UpstreamState = { ws, buffer: [], open: false };
+      upstreams.set(peer.id, state);
+
+      ws.addEventListener("open", () => {
+        state.open = true;
+        for (const data of state.buffer) {
+          ws.send(data as Parameters<WebSocket["send"]>[0]);
+        }
+        state.buffer.length = 0;
+      });
+
+      ws.addEventListener("message", (event) => {
+        peer.send(event.data);
+      });
+
+      ws.addEventListener("close", (event) => {
+        upstreams.delete(peer.id);
+        _safeClose(peer, event.code, event.reason);
+      });
+
+      ws.addEventListener("error", () => {
+        upstreams.delete(peer.id);
+        _safeClose(peer, 1011, "Upstream error");
+      });
+    },
+
+    message(peer, message) {
+      const state = upstreams.get(peer.id);
+      if (!state) return;
+      const data =
+        typeof message.rawData === "string"
+          ? message.rawData
+          : message.uint8Array();
+      if (state.open) {
+        state.ws.send(data as Parameters<WebSocket["send"]>[0]);
+      } else {
+        state.buffer.push(data);
+      }
+    },
+
+    close(peer, details) {
+      const state = upstreams.get(peer.id);
+      if (!state) return;
+      upstreams.delete(peer.id);
+      try {
+        state.ws.close(details.code, details.reason);
+      } catch {
+        // ignore invalid code/reason
+      }
+    },
+
+    error(peer) {
+      const state = upstreams.get(peer.id);
+      if (!state) return;
+      upstreams.delete(peer.id);
+      try {
+        state.ws.close();
+      } catch {
+        // ignore
+      }
+    },
+  };
+}
+
+// --- internals ---
+
+interface UpstreamState {
+  ws: WebSocket;
+  buffer: unknown[];
+  open: boolean;
+}
+
+function _resolveTarget(
+  target: WebSocketProxyOptions["target"],
+  peer: Peer,
+): URL {
+  const raw = typeof target === "function" ? target(peer) : target;
+  return raw instanceof URL ? raw : new URL(raw);
+}
+
+function _resolveProtocols(
+  peer: Peer,
+  forwardProtocol: boolean | undefined,
+): string[] | undefined {
+  if (forwardProtocol === false) return;
+  const header = peer.request?.headers.get("sec-websocket-protocol");
+  if (!header) return;
+  return header.split(",").map((p) => p.trim()).filter(Boolean);
+}
+
+function _safeClose(peer: Peer, code?: number, reason?: string): void {
+  try {
+    peer.close(code, reason);
+  } catch {
+    // ignore
+  }
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -8,6 +8,11 @@ const DEFAULT_MAX_BUFFER_SIZE = 1024 * 1024;
 // 10 seconds — aligns with common reverse-proxy defaults (nginx, haproxy).
 const DEFAULT_CONNECT_TIMEOUT = 10_000;
 
+// RFC 7230 `token` grammar — the on-wire form of a WebSocket subprotocol
+// per RFC 6455 §4.1. Used to validate values we echo back in the upgrade
+// response so client-controlled input can't coerce unexpected header content.
+const TOKEN_RE = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+
 export interface WebSocketProxyOptions {
   /**
    * Target WebSocket URL to proxy to (`ws://` or `wss://`).
@@ -51,6 +56,34 @@ export interface WebSocketProxyOptions {
    * @default globalThis.WebSocket
    */
   WebSocket?: typeof WebSocket;
+
+  /**
+   * Extra headers to send on the upstream handshake. Can be a static
+   * object or a resolver called per peer.
+   *
+   * Useful to forward identity from the incoming request (`cookie`,
+   * `authorization`, `origin`), or to inject a shared secret the
+   * upstream expects.
+   *
+   * > [!NOTE]
+   * > The WHATWG global `WebSocket` constructor does not accept custom
+   * > headers — this option is only honored by `WebSocket` constructors
+   * > that take a third options argument (e.g. `ws`, `undici`). Pass
+   * > one via the {@link WebSocket} option to use it.
+   *
+   * @example
+   * ```ts
+   * createWebSocketProxy({
+   *   target: "wss://backend.example.com",
+   *   WebSocket: WsFromNodeWs,
+   *   headers: (peer) => ({
+   *     cookie: peer.request.headers.get("cookie") ?? "",
+   *     "x-forwarded-for": peer.remoteAddress ?? "",
+   *   }),
+   * });
+   * ```
+   */
+  headers?: HeadersInit | ((peer: Peer) => HeadersInit | undefined | void);
 }
 
 /**
@@ -92,15 +125,42 @@ export function createWebSocketProxy(
       // Accept the first requested subprotocol so the upgrade handshake
       // echoes a value the client expects. Upstream must support it too.
       const accepted = reqProtocol.split(",")[0]!.trim();
+      // Defense-in-depth: only echo RFC 7230 tokens. The Fetch `Headers`
+      // API already rejects CRLF, but restricting to the subprotocol
+      // grammar ensures no other client-controlled bytes can land in a
+      // response header — even under buggy or custom header writers.
+      if (!TOKEN_RE.test(accepted)) {
+        return;
+      }
       return { headers: { "sec-websocket-protocol": accepted } };
     },
 
     open(peer) {
-      const url = _resolveTarget(options.target, peer);
-      const protocols = _resolveProtocols(peer, options.forwardProtocol);
-
-      const ws = new WebSocketCtor(url, protocols);
-      ws.binaryType = "arraybuffer";
+      let ws: WebSocket;
+      try {
+        const url = _resolveTarget(options.target, peer);
+        const protocols = _resolveProtocols(peer, options.forwardProtocol);
+        const wsOptions = _resolveWsOptions(options.headers, peer);
+        // The WHATWG WebSocket constructor only takes (url, protocols);
+        // additional arguments are ignored. Custom clients like `ws` and
+        // `undici` accept a third options object where `headers` is
+        // honored — so always pass it when the user configured headers.
+        ws = wsOptions
+          ? new (WebSocketCtor as unknown as new (
+              url: URL,
+              protocols: string[] | undefined,
+              opts: { headers: HeadersInit },
+            ) => WebSocket)(url, protocols, wsOptions)
+          : new WebSocketCtor(url, protocols);
+        ws.binaryType = "arraybuffer";
+      } catch {
+        // Bad target URL, disallowed scheme, invalid subprotocol token,
+        // or a throwing custom resolver — close the peer with a
+        // generic internal-error code rather than letting the exception
+        // escape the hook.
+        _safeClose(peer, 1011, "Upstream setup failed");
+        return;
+      }
 
       const state: UpstreamState = {
         ws,
@@ -165,7 +225,13 @@ export function createWebSocketProxy(
         }
         return;
       }
-      const size = typeof raw === "string" ? raw.length : raw.byteLength;
+      // Strings become UTF-8 on the wire: a UTF-16 code unit encodes to
+      // at most 3 UTF-8 bytes (surrogate pairs use 4 bytes spread across
+      // 2 code units, so the per-unit worst case still bounds at 3).
+      // Use the upper bound to keep the check O(1) while guaranteeing
+      // the buffered payload can't exceed the configured limit on the
+      // wire, even for multi-byte content.
+      const size = typeof raw === "string" ? raw.length * 3 : raw.byteLength;
       const limit = options.maxBufferSize ?? DEFAULT_MAX_BUFFER_SIZE;
       if (limit > 0 && state.bufferSize + size > limit) {
         _cleanupState(upstreams, peer.id, state);
@@ -245,6 +311,16 @@ function _resolveTarget(
 ): URL {
   const raw = typeof target === "function" ? target(peer) : target;
   return raw instanceof URL ? raw : new URL(raw);
+}
+
+function _resolveWsOptions(
+  headers: WebSocketProxyOptions["headers"],
+  peer: Peer,
+): { headers: HeadersInit } | undefined {
+  if (!headers) return;
+  const resolved = typeof headers === "function" ? headers(peer) : headers;
+  if (!resolved) return;
+  return { headers: resolved };
 }
 
 function _resolveProtocols(

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -237,11 +237,134 @@ describe("createWebSocketProxy", () => {
       ws.ws.addEventListener("close", (e) => resolve(e as CloseEvent));
     });
     // Upstream has a 100ms upgrade delay, so these messages queue in the
-    // proxy's buffer before the upstream connection opens.
-    await ws.send("aaaaa"); // 5 bytes — fills the limit exactly
-    await ws.send("bbbbb"); // 5 more bytes — exceeds
+    // proxy's buffer before the upstream connection opens. The proxy
+    // accounts strings at their UTF-8 worst case (3 bytes per code unit)
+    // so any non-empty frame exceeds the 5-byte limit configured above.
+    await ws.send("aaaaa");
     const event = await closed;
     expect(event.code).toBe(1009);
+  });
+});
+
+describe("createWebSocketProxy unit hooks", () => {
+  test("echoes valid subprotocol tokens in upgrade response", () => {
+    const hooks = createWebSocketProxy("ws://localhost/");
+    const req = new Request("http://localhost/", {
+      headers: { "sec-websocket-protocol": "chat" },
+    });
+    const result = hooks.upgrade?.(req);
+    expect(result).toMatchObject({
+      headers: { "sec-websocket-protocol": "chat" },
+    });
+  });
+
+  test("drops subprotocol values that are not RFC 7230 tokens", () => {
+    // Defense-in-depth: even if a buggy runtime lets a client smuggle a
+    // non-token character into the header, the proxy must not echo it
+    // into the upgrade response.
+    const hooks = createWebSocketProxy("ws://localhost/");
+    for (const bad of ["a/b", "has space", "semi;colon", "ctl\u0001"]) {
+      const req = new Request("http://localhost/", {
+        headers: { "sec-websocket-protocol": bad },
+      });
+      expect(hooks.upgrade?.(req)).toBeUndefined();
+    }
+  });
+
+  test("passes headers option through to custom WebSocket constructor", () => {
+    const calls: Array<{
+      url: unknown;
+      protocols: unknown;
+      options: unknown;
+    }> = [];
+    class StubWS extends EventTarget {
+      binaryType = "arraybuffer";
+      readyState = 0;
+      constructor(url: unknown, protocols: unknown, options?: unknown) {
+        super();
+        calls.push({ url, protocols, options });
+      }
+      send(): void {}
+      close(): void {}
+    }
+    const hooks = createWebSocketProxy({
+      target: "ws://upstream.invalid/",
+      WebSocket: StubWS as unknown as typeof WebSocket,
+      connectTimeout: 0,
+      headers: (peer) => ({
+        cookie: peer.request?.headers.get("cookie") ?? "",
+        "x-trace": "t1",
+      }),
+    });
+    const peer = {
+      id: "p-headers",
+      request: new Request("http://localhost/", {
+        headers: { cookie: "sid=abc" },
+      }),
+      close() {},
+      send() {},
+    };
+    hooks.open?.(peer as never);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.options).toEqual({
+      headers: { cookie: "sid=abc", "x-trace": "t1" },
+    });
+  });
+
+  test("closes peer with 1011 when WebSocket constructor rejects the target", async () => {
+    // The WHATWG `WebSocket` constructor throws `SyntaxError` for any
+    // scheme other than `ws:`/`wss:`. The open hook must catch that
+    // and close the peer instead of letting the exception escape.
+    const badAdapter = nodeAdapter({
+      hooks: createWebSocketProxy({
+        target: () => new URL("http://localhost:1/"),
+      }),
+    });
+    const server = createServer((_req, res) => res.end("ok"));
+    server.on("upgrade", badAdapter.handleUpgrade);
+    const port = await getRandomPort("localhost");
+    await new Promise<void>((resolve) => server.listen(port, resolve));
+    await waitForPort(port);
+    try {
+      const ws = await wsConnect(`ws://localhost:${port}/`);
+      const event = await new Promise<CloseEvent>((resolve) => {
+        ws.ws.addEventListener("close", (e) => resolve(e as CloseEvent));
+      });
+      expect(event.code).toBe(1011);
+    } finally {
+      server.closeAllConnections?.();
+      server.close();
+    }
+  });
+
+  test("passes ws+unix targets through to a custom WebSocket client", () => {
+    // No built-in scheme validation: anything the custom constructor
+    // accepts (e.g. the `ws+unix:` syntax supported by `ws`) works.
+    const calls: unknown[] = [];
+    class StubWS extends EventTarget {
+      binaryType = "arraybuffer";
+      readyState = 0;
+      constructor(url: unknown) {
+        super();
+        calls.push(url);
+      }
+      send(): void {}
+      close(): void {}
+    }
+    const hooks = createWebSocketProxy({
+      target: "ws+unix:/tmp/sock:/",
+      WebSocket: StubWS as unknown as typeof WebSocket,
+      connectTimeout: 0,
+    });
+    const peer = {
+      id: "p-unix",
+      request: new Request("http://localhost/"),
+      close() {},
+      send() {},
+    };
+    hooks.open?.(peer as never);
+    expect(calls).toHaveLength(1);
+    expect(String(calls[0])).toContain("ws+unix:");
   });
 });
 

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -3,6 +3,7 @@ import { createServer, Server } from "node:http";
 import { getRandomPort, waitForPort } from "get-port-please";
 import nodeAdapter from "../src/adapters/node.ts";
 import { createWebSocketProxy, defineHooks } from "../src/index.ts";
+import { _normalizeOutgoingCode, _remapIncomingCode } from "../src/proxy.ts";
 import { wsConnect } from "./_utils.ts";
 
 describe("createWebSocketProxy", () => {
@@ -18,7 +19,6 @@ describe("createWebSocketProxy", () => {
   let limitedProxyURL: string;
   let badProxyURL: string;
   let timeoutProxyURL: string;
-
   beforeAll(async () => {
     // Upstream echo server (crossws node adapter)
     const upstream = nodeAdapter({
@@ -242,5 +242,33 @@ describe("createWebSocketProxy", () => {
     await ws.send("bbbbb"); // 5 more bytes — exceeds
     const event = await closed;
     expect(event.code).toBe(1009);
+  });
+});
+
+describe("createWebSocketProxy internals", () => {
+  test("_normalizeOutgoingCode allows 1000 and 3000-4999 range", () => {
+    // state.ws is a client-side WebSocket; WHATWG forbids anything else.
+    expect(_normalizeOutgoingCode(undefined)).toBeUndefined();
+    expect(_normalizeOutgoingCode(1000)).toBe(1000);
+    expect(_normalizeOutgoingCode(3000)).toBe(3000);
+    expect(_normalizeOutgoingCode(4999)).toBe(4999);
+  });
+
+  test("_normalizeOutgoingCode rewrites reserved and disallowed codes to 1000", () => {
+    // Regression: state.ws.close(1005) would throw InvalidAccessError,
+    // leaking the upstream socket. 1001/1008 are valid server-side codes
+    // but still forbidden for client-side close(), so they also normalize.
+    for (const code of [1001, 1005, 1006, 1008, 1011, 1015, 2999, 5000]) {
+      expect(_normalizeOutgoingCode(code)).toBe(1000);
+    }
+  });
+
+  test("_remapIncomingCode rewrites reserved pseudo-codes before peer close", () => {
+    expect(_remapIncomingCode(undefined)).toBeUndefined();
+    expect(_remapIncomingCode(1000)).toBe(1000);
+    expect(_remapIncomingCode(1005)).toBe(1000);
+    expect(_remapIncomingCode(1006)).toBe(1011);
+    expect(_remapIncomingCode(1015)).toBe(1011);
+    expect(_remapIncomingCode(4321)).toBe(4321);
   });
 });

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -2,17 +2,22 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { createServer, Server } from "node:http";
 import { getRandomPort, waitForPort } from "get-port-please";
 import nodeAdapter from "../src/adapters/node.ts";
-import { defineHooks } from "../src/index.ts";
-import { createWebSocketProxy } from "../src/proxy.ts";
+import { createWebSocketProxy, defineHooks } from "../src/index.ts";
 import { wsConnect } from "./_utils.ts";
 
 describe("createWebSocketProxy", () => {
   let upstreamServer: Server;
   let proxyServer: Server;
   let dynamicProxyServer: Server;
+  let limitedProxyServer: Server;
+  let badProxyServer: Server;
+  let timeoutProxyServer: Server;
   let upstreamURL: string;
   let proxyURL: string;
   let dynamicProxyURL: string;
+  let limitedProxyURL: string;
+  let badProxyURL: string;
+  let timeoutProxyURL: string;
 
   beforeAll(async () => {
     // Upstream echo server (crossws node adapter)
@@ -21,18 +26,33 @@ describe("createWebSocketProxy", () => {
         open(peer) {
           peer.send("welcome");
         },
+        async upgrade(req) {
+          const { pathname } = new URL(req.url);
+          if (pathname === "/slow") {
+            await new Promise((r) => setTimeout(r, 100));
+          }
+          if (req.headers.get("sec-websocket-protocol") === "chat") {
+            return { headers: { "sec-websocket-protocol": "chat" } };
+          }
+        },
         message(peer, message) {
           const text = message.text();
           if (text === "getbinary") {
             peer.send(new TextEncoder().encode("binary-pong"));
-          } else {
-            peer.send(`echo:${text}`);
+            return;
           }
-        },
-        upgrade(req) {
-          if (req.headers.get("sec-websocket-protocol") === "chat") {
-            return { headers: { "sec-websocket-protocol": "chat" } };
+          if (text === "type") {
+            const kind =
+              typeof message.rawData === "string" ? "text" : "binary";
+            peer.send(`type:${kind}`);
+            return;
           }
+          if (text.startsWith("close:")) {
+            const [, codeStr, reason] = text.split(":");
+            peer.close(Number(codeStr), reason);
+            return;
+          }
+          peer.send(`echo:${text}`);
         },
       }),
     });
@@ -70,10 +90,63 @@ describe("createWebSocketProxy", () => {
       dynamicProxyServer.listen(dynamicProxyPort, resolve),
     );
     await waitForPort(dynamicProxyPort);
+
+    // Proxy with a small buffer limit pointing at a slow-upgrade path
+    const limitedProxy = nodeAdapter({
+      hooks: createWebSocketProxy({
+        target: `${upstreamURL}slow`,
+        maxBufferSize: 5,
+      }),
+    });
+    limitedProxyServer = createServer((_req, res) => res.end("ok"));
+    limitedProxyServer.on("upgrade", limitedProxy.handleUpgrade);
+    const limitedProxyPort = await getRandomPort("localhost");
+    limitedProxyURL = `ws://localhost:${limitedProxyPort}/`;
+    await new Promise<void>((resolve) =>
+      limitedProxyServer.listen(limitedProxyPort, resolve),
+    );
+    await waitForPort(limitedProxyPort);
+
+    // Proxy pointing at a port with nothing listening
+    const deadPort = await getRandomPort("localhost");
+    const badProxy = nodeAdapter({
+      hooks: createWebSocketProxy(`ws://localhost:${deadPort}/`),
+    });
+    badProxyServer = createServer((_req, res) => res.end("ok"));
+    badProxyServer.on("upgrade", badProxy.handleUpgrade);
+    const badProxyPort = await getRandomPort("localhost");
+    badProxyURL = `ws://localhost:${badProxyPort}/`;
+    await new Promise<void>((resolve) =>
+      badProxyServer.listen(badProxyPort, resolve),
+    );
+    await waitForPort(badProxyPort);
+
+    // Proxy with a small connect timeout pointing at the slow-upgrade path
+    const timeoutProxy = nodeAdapter({
+      hooks: createWebSocketProxy({
+        target: `${upstreamURL}slow`,
+        connectTimeout: 25,
+      }),
+    });
+    timeoutProxyServer = createServer((_req, res) => res.end("ok"));
+    timeoutProxyServer.on("upgrade", timeoutProxy.handleUpgrade);
+    const timeoutProxyPort = await getRandomPort("localhost");
+    timeoutProxyURL = `ws://localhost:${timeoutProxyPort}/`;
+    await new Promise<void>((resolve) =>
+      timeoutProxyServer.listen(timeoutProxyPort, resolve),
+    );
+    await waitForPort(timeoutProxyPort);
   });
 
   afterAll(() => {
-    for (const server of [proxyServer, dynamicProxyServer, upstreamServer]) {
+    for (const server of [
+      proxyServer,
+      dynamicProxyServer,
+      limitedProxyServer,
+      badProxyServer,
+      timeoutProxyServer,
+      upstreamServer,
+    ]) {
       server.closeAllConnections?.();
       server.close();
     }
@@ -90,6 +163,14 @@ describe("createWebSocketProxy", () => {
     expect(await ws.next()).toBe("echo:hello");
     await ws.send("world");
     expect(await ws.next()).toBe("echo:world");
+  });
+
+  test("forwards text frames as text (not binary)", async () => {
+    // Regression: on Node's `ws` lib, text frames arrive as Buffer.
+    // The Node adapter must decode them so downstream hooks see a string.
+    const ws = await wsConnect(proxyURL, { skip: 1 });
+    await ws.send("type");
+    expect(await ws.next()).toBe("type:text");
   });
 
   test("forwards binary messages", async () => {
@@ -121,5 +202,45 @@ describe("createWebSocketProxy", () => {
     const ws = await wsConnect(dynamicProxyURL, { skip: 1 });
     await ws.send("dyn");
     expect(await ws.next()).toBe("echo:dyn");
+  });
+
+  test("propagates upstream close code", async () => {
+    const ws = await wsConnect(proxyURL, { skip: 1 });
+    const closed = new Promise<CloseEvent>((resolve) => {
+      ws.ws.addEventListener("close", (e) => resolve(e as CloseEvent));
+    });
+    await ws.send("close:4321:bye");
+    const event = await closed;
+    expect(event.code).toBe(4321);
+  });
+
+  test("closes peer with 1011 when upstream cannot connect", async () => {
+    const ws = await wsConnect(badProxyURL);
+    const event = await new Promise<CloseEvent>((resolve) => {
+      ws.ws.addEventListener("close", (e) => resolve(e as CloseEvent));
+    });
+    expect(event.code).toBe(1011);
+  });
+
+  test("closes peer with 1011 when upstream handshake times out", async () => {
+    // Upstream has a 100ms upgrade delay, proxy's connectTimeout is 25ms.
+    const ws = await wsConnect(timeoutProxyURL);
+    const event = await new Promise<CloseEvent>((resolve) => {
+      ws.ws.addEventListener("close", (e) => resolve(e as CloseEvent));
+    });
+    expect(event.code).toBe(1011);
+  });
+
+  test("enforces maxBufferSize limit", async () => {
+    const ws = await wsConnect(limitedProxyURL);
+    const closed = new Promise<CloseEvent>((resolve) => {
+      ws.ws.addEventListener("close", (e) => resolve(e as CloseEvent));
+    });
+    // Upstream has a 100ms upgrade delay, so these messages queue in the
+    // proxy's buffer before the upstream connection opens.
+    await ws.send("aaaaa"); // 5 bytes — fills the limit exactly
+    await ws.send("bbbbb"); // 5 more bytes — exceeds
+    const event = await closed;
+    expect(event.code).toBe(1009);
   });
 });

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,0 +1,125 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { createServer, Server } from "node:http";
+import { getRandomPort, waitForPort } from "get-port-please";
+import nodeAdapter from "../src/adapters/node.ts";
+import { defineHooks } from "../src/index.ts";
+import { createWebSocketProxy } from "../src/proxy.ts";
+import { wsConnect } from "./_utils.ts";
+
+describe("createWebSocketProxy", () => {
+  let upstreamServer: Server;
+  let proxyServer: Server;
+  let dynamicProxyServer: Server;
+  let upstreamURL: string;
+  let proxyURL: string;
+  let dynamicProxyURL: string;
+
+  beforeAll(async () => {
+    // Upstream echo server (crossws node adapter)
+    const upstream = nodeAdapter({
+      hooks: defineHooks({
+        open(peer) {
+          peer.send("welcome");
+        },
+        message(peer, message) {
+          const text = message.text();
+          if (text === "getbinary") {
+            peer.send(new TextEncoder().encode("binary-pong"));
+          } else {
+            peer.send(`echo:${text}`);
+          }
+        },
+        upgrade(req) {
+          if (req.headers.get("sec-websocket-protocol") === "chat") {
+            return { headers: { "sec-websocket-protocol": "chat" } };
+          }
+        },
+      }),
+    });
+    upstreamServer = createServer((_req, res) => res.end("ok"));
+    upstreamServer.on("upgrade", upstream.handleUpgrade);
+    const upstreamPort = await getRandomPort("localhost");
+    upstreamURL = `ws://localhost:${upstreamPort}/`;
+    await new Promise<void>((resolve) =>
+      upstreamServer.listen(upstreamPort, resolve),
+    );
+    await waitForPort(upstreamPort);
+
+    // Proxy server using createWebSocketProxy hooks
+    const proxy = nodeAdapter({
+      hooks: createWebSocketProxy(upstreamURL),
+    });
+    proxyServer = createServer((_req, res) => res.end("ok"));
+    proxyServer.on("upgrade", proxy.handleUpgrade);
+    const proxyPort = await getRandomPort("localhost");
+    proxyURL = `ws://localhost:${proxyPort}/`;
+    await new Promise<void>((resolve) =>
+      proxyServer.listen(proxyPort, resolve),
+    );
+    await waitForPort(proxyPort);
+
+    // Proxy server using dynamic target function
+    const dynamicProxy = nodeAdapter({
+      hooks: createWebSocketProxy({ target: () => upstreamURL }),
+    });
+    dynamicProxyServer = createServer((_req, res) => res.end("ok"));
+    dynamicProxyServer.on("upgrade", dynamicProxy.handleUpgrade);
+    const dynamicProxyPort = await getRandomPort("localhost");
+    dynamicProxyURL = `ws://localhost:${dynamicProxyPort}/`;
+    await new Promise<void>((resolve) =>
+      dynamicProxyServer.listen(dynamicProxyPort, resolve),
+    );
+    await waitForPort(dynamicProxyPort);
+  });
+
+  afterAll(() => {
+    for (const server of [proxyServer, dynamicProxyServer, upstreamServer]) {
+      server.closeAllConnections?.();
+      server.close();
+    }
+  });
+
+  test("forwards welcome message from upstream", async () => {
+    const ws = await wsConnect(proxyURL);
+    expect(await ws.next()).toBe("welcome");
+  });
+
+  test("forwards text messages bidirectionally", async () => {
+    const ws = await wsConnect(proxyURL, { skip: 1 });
+    await ws.send("hello");
+    expect(await ws.next()).toBe("echo:hello");
+    await ws.send("world");
+    expect(await ws.next()).toBe("echo:world");
+  });
+
+  test("forwards binary messages", async () => {
+    const ws = await wsConnect(proxyURL, { skip: 1 });
+    await ws.send("getbinary");
+    // wsConnect decodes incoming binary frames as UTF-8 text
+    expect(await ws.next()).toBe("binary-pong");
+  });
+
+  test("forwards subprotocol negotiation", async () => {
+    const ws = await wsConnect(proxyURL, {
+      headers: { "sec-websocket-protocol": "chat" },
+    });
+    expect(ws.inspector.headers).toMatchObject({
+      "sec-websocket-protocol": "chat",
+    });
+  });
+
+  test("buffers messages sent before upstream is open", async () => {
+    // The client "open" event fires once the proxy handshake completes,
+    // but the upstream WebSocket is still connecting inside the `open` hook,
+    // so early messages must be buffered by the proxy.
+    const ws = await wsConnect(proxyURL, { skip: 1 });
+    await ws.send("early");
+    expect(await ws.next()).toBe("echo:early");
+  });
+
+  test("accepts dynamic target function", async () => {
+    const ws = await wsConnect(dynamicProxyURL, { skip: 1 });
+    await ws.send("dyn");
+    expect(await ws.next()).toBe("echo:dyn");
+  });
+});


### PR DESCRIPTION
Closes #93.

Adds `createWebSocketProxy(target)` in [`src/proxy.ts`](src/proxy.ts) — returns a standard crossws `Partial<Hooks>` object that forwards every peer to an upstream `ws://` or `wss://` target.

- Static URLs, `URL` instances, or `(peer) => url` resolvers
- Text/binary forwarding in both directions, close/error propagation
- Buffers client messages until the upstream is open (with `maxBufferSize` limit)
- `connectTimeout`, `forwardProtocol`, `headers`, and custom `WebSocket` constructor options
- Documented under [`docs/1.guide/7.proxy.md`](docs/1.guide/7.proxy.md), including SSRF and open-relay warnings

## Note: node adapter behavior change

[`src/adapters/node.ts`](src/adapters/node.ts) now decodes text frames to `string` before dispatching, matching every other adapter. Previously `message.rawData` was a `Buffer` for text frames on Node — anyone branching on `typeof message.rawData` will see different results. This is a prerequisite for the proxy to forward text frames as text (Node's `ws` delivers them as `Buffer` otherwise), but it is a standalone fix worth calling out in the changelog.