### PR TITLE
feat: add `fromNodeUpgradeHandler` util + socket.io example

### DIFF
--- a/docs/2.adapters/node.md
+++ b/docs/2.adapters/node.md
@@ -44,7 +44,7 @@ If you already have a Node.js WebSocket library that exposes a raw `(req, socket
 
 ```ts
 import { WebSocketServer } from "ws";
-import { fromNodeUpgradeHandler } from "crossws";
+import { fromNodeUpgradeHandler } from "crossws/adapters/node";
 import { serve } from "crossws/server/node";
 
 const wss = new WebSocketServer({ noServer: true });

--- a/docs/2.adapters/node.md
+++ b/docs/2.adapters/node.md
@@ -38,6 +38,35 @@ server.on("upgrade", (req, socket, head) => {
 See [`test/fixture/node.ts`](https://github.com/h3js/crossws/blob/main/test/fixture/node.ts) for demo and [`src/adapters/node.ts`](https://github.com/h3js/crossws/blob/main/src/adapters/node.ts) for implementation.
 ::
 
+## Delegating to an existing Node.js upgrade handler
+
+If you already have a Node.js WebSocket library that exposes a raw `(req, socket, head)` upgrade handler (e.g. [`ws`](https://github.com/websockets/ws), `socket.io`, `express-ws`), you can route to it through crossws using `fromNodeUpgradeHandler`. This lets you keep crossws's upgrade-time request handling while delegating the WebSocket lifecycle to your existing library.
+
+```ts
+import { WebSocketServer } from "ws";
+import { fromNodeUpgradeHandler } from "crossws";
+import { serve } from "crossws/server/node";
+
+const wss = new WebSocketServer({ noServer: true });
+wss.on("connection", (ws) => {
+  ws.on("message", (data) => ws.send(data));
+});
+
+serve({
+  fetch: () => new Response("ok"),
+  websocket: fromNodeUpgradeHandler((req, socket, head) => {
+    wss.handleUpgrade(req, socket, head, (ws) => {
+      wss.emit("connection", ws, req);
+    });
+  }),
+});
+```
+
+The underlying handler takes full ownership of the socket, so crossws's other lifecycle hooks (`open`, `message`, `close`, `error`) are **not** invoked for connections routed through it — manage the WebSocket lifecycle inside your own library as usual.
+
+> [!NOTE]
+> `fromNodeUpgradeHandler` only works on the Node.js runtime, and must be used via the crossws node server plugin so the request carries `runtime.node.upgrade.{socket, head}`.
+
 ## uWebSockets
 
 You can alternatively use [uWebSockets.js](https://github.com/uNetworking/uWebSockets.js) for Node.js servers.

--- a/docs/2.adapters/node.md
+++ b/docs/2.adapters/node.md
@@ -100,3 +100,49 @@ server.listen(3001, () => {
 ::read-more
 See [`test/fixture/node-uws.ts`](https://github.com/h3js/crossws/blob/main/test/fixture/node-uws.ts) for demo and [`src/adapters/node-uws.ts`](https://github.com/h3js/crossws/blob/main/src/adapters/node-uws.ts) for implementation.
 ::
+
+## Socket.IO
+
+[Socket.IO](https://socket.io/) speaks two transports: a WebSocket upgrade and an HTTP long-polling fallback served under `/socket.io/`. Both can be routed through crossws by combining `fromNodeUpgradeHandler` with srvx's `fetchNodeHandler` helper to forward the polling path (and the optional client bundle at `/socket.io/socket.io.js`) to socket.io's own Node-style `(req, res)` listener:
+
+```ts
+import { createServer } from "node:http";
+import { Server as SocketIOServer } from "socket.io";
+import { fromNodeUpgradeHandler } from "crossws/adapters/node";
+import { serve } from "crossws/server/node";
+import { fetchNodeHandler } from "srvx/node";
+
+// Attach socket.io to a throwaway http.Server — it never `.listen()`s,
+// but the dummy server now holds socket.io's own `request` listener,
+// which handles the client bundle AND delegates polling to engine.io.
+const dummyServer = createServer();
+const io = new SocketIOServer(dummyServer, { serveClient: true });
+const [socketIoRequestListener] = dummyServer.listeners("request");
+
+io.on("connection", (socket) => {
+  socket.emit("welcome", { id: socket.id });
+  socket.on("message", (text) => io.emit("message", { from: socket.id, text }));
+});
+
+const server = serve({
+  port: 3000,
+  async fetch(req) {
+    const url = new URL(req.url);
+    if (url.pathname.startsWith("/socket.io/")) {
+      return fetchNodeHandler(socketIoRequestListener, req);
+    }
+    return new Response("ok");
+  },
+  websocket: fromNodeUpgradeHandler((req, socket, head) => {
+    io.engine.handleUpgrade(req, socket, head);
+  }),
+});
+
+await server.ready();
+```
+
+If you only need the WebSocket transport, force the client to skip polling with `io(url, { transports: ["websocket"] })` and you can drop the `fetch`-side delegation entirely.
+
+::read-more
+See [`examples/socket.io`](https://github.com/h3js/crossws/tree/main/examples/socket.io) for a runnable demo including a browser client.
+::

--- a/examples/socket.io/package.json
+++ b/examples/socket.io/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "crossws-example-socket.io",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "node server.mjs"
+  },
+  "dependencies": {
+    "crossws": "workspace:*",
+    "socket.io": "^4.8.1",
+    "srvx": "latest"
+  }
+}

--- a/examples/socket.io/public/index.html
+++ b/examples/socket.io/public/index.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>crossws + socket.io</title>
+    <style>
+      body {
+        font-family: system-ui, sans-serif;
+        max-width: 40rem;
+        margin: 2rem auto;
+        padding: 0 1rem;
+      }
+      #log {
+        list-style: none;
+        padding: 0;
+        margin-top: 1rem;
+      }
+      #log li {
+        padding: 0.25rem 0;
+        border-bottom: 1px solid #eee;
+        font-family: ui-monospace, monospace;
+        font-size: 0.85rem;
+      }
+      form {
+        display: flex;
+        gap: 0.5rem;
+      }
+      input {
+        flex: 1;
+        padding: 0.5rem;
+      }
+      button {
+        padding: 0.5rem 1rem;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>crossws + socket.io</h1>
+    <form id="form">
+      <input id="input" autocomplete="off" placeholder="message" />
+      <button type="submit">send</button>
+    </form>
+    <ul id="log"></ul>
+
+    <script src="/socket.io/socket.io.js"></script>
+    <script>
+      const socket = io();
+      const logEl = document.getElementById("log");
+      const log = (line) => {
+        const li = document.createElement("li");
+        li.textContent = line;
+        logEl.prepend(li);
+      };
+
+      socket.on("connect", () => log(`[connect] ${socket.id}`));
+      socket.on("disconnect", (reason) => log(`[disconnect] ${reason}`));
+      socket.on("welcome", (m) => log(`[welcome] ${JSON.stringify(m)}`));
+      socket.on("message", (m) => log(`[message] ${JSON.stringify(m)}`));
+
+      document.getElementById("form").addEventListener("submit", (e) => {
+        e.preventDefault();
+        const input = document.getElementById("input");
+        if (!input.value) return;
+        socket.emit("message", input.value);
+        input.value = "";
+      });
+    </script>
+  </body>
+</html>

--- a/examples/socket.io/server.mjs
+++ b/examples/socket.io/server.mjs
@@ -1,0 +1,78 @@
+// Socket.IO integration example.
+//
+// Socket.IO uses two transports: WebSocket (upgrade) and HTTP long-polling.
+// We route each through crossws:
+//   - WebSocket upgrades → `fromNodeUpgradeHandler` → `io.engine.handleUpgrade`
+//   - `/socket.io/*` HTTP requests → `fetchNodeHandler` → socket.io's own
+//     `request` listener (which handles the client bundle AND delegates
+//     polling requests to `io.engine.handleRequest`)
+//
+// Run with: `pnpm start` (from this directory).
+
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { Server as SocketIOServer } from "socket.io";
+import { fromNodeUpgradeHandler } from "crossws/adapters/node";
+import { serve } from "crossws/server/node";
+import { fetchNodeHandler } from "srvx/node";
+
+// Socket.IO initializes `io.engine` inside `attach()`. We attach to a
+// throwaway `http.Server` that never `.listen()`s — its request/upgrade
+// listeners are never invoked, but the dummy server now holds socket.io's
+// own `request` listener, which we reuse below to serve both the client
+// bundle and the polling transport.
+const dummyServer = createServer();
+const io = new SocketIOServer(dummyServer, {
+  serveClient: true, // serves the client bundle at /socket.io/socket.io.js
+});
+const [socketIoRequestListener] = dummyServer.listeners("request");
+
+io.on("connection", (socket) => {
+  console.log("[io] connection", socket.id);
+  socket.emit("welcome", { from: "server", to: socket.id });
+
+  socket.on("message", (text) => {
+    console.log("[io] message", socket.id, text);
+    io.emit("message", { from: socket.id, text });
+  });
+
+  socket.on("disconnect", (reason) => {
+    console.log("[io] disconnect", socket.id, reason);
+  });
+});
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const indexHtml = await readFile(join(__dirname, "public/index.html"));
+
+const server = serve({
+  port: 3000,
+  hostname: "127.0.0.1",
+
+  async fetch(req) {
+    const url = new URL(req.url);
+
+    // Polling transport and the /socket.io/socket.io.js client bundle.
+    if (url.pathname.startsWith("/socket.io/")) {
+      return fetchNodeHandler(socketIoRequestListener, req);
+    }
+
+    if (url.pathname === "/") {
+      return new Response(indexHtml, {
+        headers: { "content-type": "text/html; charset=utf-8" },
+      });
+    }
+
+    return new Response("not found", { status: 404 });
+  },
+
+  // WebSocket transport.
+  websocket: fromNodeUpgradeHandler((req, socket, head) => {
+    io.engine.handleUpgrade(req, socket, head);
+  }),
+});
+
+await server.ready();
+console.log("→ http://127.0.0.1:3000");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -99,6 +99,18 @@ importers:
         specifier: ^8.20.0
         version: 8.20.0
 
+  examples/socket.io:
+    dependencies:
+      crossws:
+        specifier: workspace:*
+        version: link:../..
+      socket.io:
+        specifier: ^4.8.1
+        version: 4.8.3
+      srvx:
+        specifier: latest
+        version: 0.11.15
+
   playground:
     dependencies:
       crossws:
@@ -1181,6 +1193,9 @@ packages:
     resolution: {integrity: sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==}
     engines: {node: '>=18'}
 
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
+
   '@speed-highlight/core@1.2.15':
     resolution: {integrity: sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==}
 
@@ -1195,6 +1210,9 @@ packages:
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
@@ -1374,6 +1392,10 @@ packages:
   '@vitest/utils@4.1.4':
     resolution: {integrity: sha512-13QMT+eysM5uVGa1rG4kegGYNp6cnQcsTc67ELFbhNLQO+vgsygtYJx2khvdt4gVQqSSpC/KT5FZZxUpP3Oatw==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -1416,6 +1438,10 @@ packages:
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
 
   baseline-browser-mapping@2.10.17:
     resolution: {integrity: sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==}
@@ -1549,12 +1575,20 @@ packages:
   cookie-es@1.2.3:
     resolution: {integrity: sha512-lXVyvUvrNXblMqzIRrxHb57UUVmqsSWlxqt3XIjCkUP0wDAf6uicO6KMbEgYrMNtEvWgWHwe42CKxPu9MYAnWw==}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
   core-js-compat@3.49.0:
     resolution: {integrity: sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1688,6 +1722,14 @@ packages:
 
   electron-to-chromium@1.5.334:
     resolution: {integrity: sha512-mgjZAz7Jyx1SRCwEpy9wefDS7GvNPazLthHg8eQMJ76wBdGQQDW33TCrUTvQ4wzpmOrv2zrFoD3oNufMdyMpog==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.6:
+    resolution: {integrity: sha512-U2SN0w3OpjFRVlrc17E6TMDmH58Xl9rai1MblNjAdwWp07Kk+llmzX0hjDpQdrDGzwmvOtgM5yI+meYX6iZ2xA==}
+    engines: {node: '>=10.2.0'}
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
@@ -2307,6 +2349,14 @@ packages:
   micromark@4.0.2:
     resolution: {integrity: sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
   miniflare@4.20260409.0:
     resolution: {integrity: sha512-ayl6To4av0YuXsSivGgWLj+Ug8xZ0Qz3sGV8+Ok2LhNVl6m8m5ktEBM3LX9iT9MtLZRJwBlJrKcraNs/DlZQfA==}
     engines: {node: '>=18.0.0'}
@@ -2358,6 +2408,10 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   node-addon-api@7.1.1:
     resolution: {integrity: sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==}
 
@@ -2380,6 +2434,10 @@ packages:
 
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2768,6 +2826,17 @@ packages:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
 
+  socket.io-adapter@2.5.6:
+    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2954,6 +3023,10 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
+
   vite@8.0.8:
     resolution: {integrity: sha512-dbU7/iLVa8KZALJyLOBOQ88nOXtNG8vxKuOT4I2mD+Ya70KPceF4IAmDsmU0h1Qsn5bPrvsY9HJstCRh3hG6Uw==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -3069,6 +3142,18 @@ packages:
 
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -3814,6 +3899,8 @@ snapshots:
 
   '@sindresorhus/merge-streams@4.0.0': {}
 
+  '@socket.io/component-emitter@3.1.2': {}
+
   '@speed-highlight/core@1.2.15': {}
 
   '@standard-schema/spec@1.1.0': {}
@@ -3831,6 +3918,10 @@ snapshots:
     dependencies:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
+
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 25.6.0
 
   '@types/debug@4.1.13':
     dependencies:
@@ -4045,6 +4136,11 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   acorn-jsx@5.3.2(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
@@ -4106,6 +4202,8 @@ snapshots:
       postcss-value-parser: 4.2.0
 
   balanced-match@4.0.4: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.10.17: {}
 
@@ -4238,11 +4336,18 @@ snapshots:
 
   cookie-es@1.2.3: {}
 
+  cookie@0.7.2: {}
+
   cookie@1.1.1: {}
 
   core-js-compat@3.49.0:
     dependencies:
       browserslist: 4.28.2
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cross-spawn@7.0.6:
     dependencies:
@@ -4386,6 +4491,25 @@ snapshots:
   dts-resolver@2.1.3: {}
 
   electron-to-chromium@1.5.334: {}
+
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.6:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 25.6.0
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   entities@4.5.0: {}
 
@@ -5211,6 +5335,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
   miniflare@4.20260409.0:
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
@@ -5262,6 +5392,8 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
+  negotiator@0.6.3: {}
+
   node-addon-api@7.1.1: {}
 
   node-fetch-native@1.6.7: {}
@@ -5280,6 +5412,8 @@ snapshots:
   nth-check@2.1.1:
     dependencies:
       boolbase: 1.0.0
+
+  object-assign@4.1.1: {}
 
   obug@2.1.1: {}
 
@@ -5729,6 +5863,36 @@ snapshots:
 
   signal-exit@4.1.0: {}
 
+  socket.io-adapter@2.5.6:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.6
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   source-map-js@1.2.1: {}
 
   spdx-compare@1.0.0:
@@ -5930,6 +6094,8 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
+  vary@1.1.2: {}
+
   vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1):
     dependencies:
       lightningcss: 1.32.0
@@ -6008,6 +6174,8 @@ snapshots:
       - utf-8-validate
 
   ws@8.18.0: {}
+
+  ws@8.18.3: {}
 
   ws@8.20.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "playground"
+  - "examples/*"

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -144,6 +144,9 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
 
 export default nodeAdapter;
 
+export { fromNodeUpgradeHandler } from "../node-handler.ts";
+export type { NodeUpgradeHandler } from "../node-handler.ts";
+
 // --- peer ---
 
 class NodePeer extends Peer<{

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -110,10 +110,16 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
     handleUpgrade: async (nodeReq, socket, head, webRequest) => {
       const request = webRequest || new NodeReqProxy(nodeReq);
 
-      const { upgradeHeaders, endResponse, context, namespace } =
+      const { upgradeHeaders, endResponse, handled, context, namespace } =
         await hooks.upgrade(request);
       if (endResponse) {
         return sendResponse(socket, endResponse);
+      }
+      // Upgrade was performed by the hook (e.g. delegated to an external
+      // node-style handler via `fromNodeUpgradeHandler`). The socket has
+      // been taken over — leave it alone.
+      if (handled) {
+        return;
       }
 
       (nodeReq as AugmentedReq)._request = request;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -76,6 +76,9 @@ export class AdapterHookable {
         return { context, namespace, endResponse: res };
       }
       if ((res as { handled?: boolean }).handled) {
+        // Hook took ownership of the socket — any `headers` returned
+        // alongside `handled` are ignored since the adapter skips its
+        // own upgrade and no response will be written from here.
         return { context, namespace, handled: true };
       }
       if (res.headers) {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -48,6 +48,7 @@ export class AdapterHookable {
     namespace: string;
     upgradeHeaders?: HeadersInit;
     endResponse?: Response;
+    handled?: boolean;
   }> {
     let namespace =
       this.options.getNamespace?.(request) ?? new URL(request.url).pathname;
@@ -73,6 +74,9 @@ export class AdapterHookable {
       }
       if (res instanceof Response) {
         return { context, namespace, endResponse: res };
+      }
+      if ((res as { handled?: boolean }).handled) {
+        return { context, namespace, handled: true };
       }
       if (res.headers) {
         return {
@@ -120,6 +124,10 @@ export interface Hooks {
    * - You can return { headers } to modify the response.
    * - You can return { namespace } to change the pub/sub namespace.
    * - You can return { context } to provide a custom peer context.
+   * - You can return { handled: true } to signal that the upgrade has
+   *   already been performed by the hook (e.g. delegated to an external
+   *   node-style `(req, socket, head)` handler). The adapter will then
+   *   leave the socket alone and skip its own upgrade.
    *
    * @param request
    * @throws {Response}
@@ -129,7 +137,12 @@ export interface Hooks {
       readonly context?: Record<string, unknown>;
     },
   ) => MaybePromise<
-    | { headers?: HeadersInit; namespace?: string; context?: PeerContext }
+    | {
+        headers?: HeadersInit;
+        namespace?: string;
+        context?: PeerContext;
+        handled?: boolean;
+      }
     | Response
     | void
   >;

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,8 +22,4 @@ export type { ServerWithWSOptions, WSOptions } from "./server/_types.ts";
 export { createWebSocketProxy } from "./proxy.ts";
 export type { WebSocketProxyOptions } from "./proxy.ts";
 
-// Node handler
-export { fromNodeUpgradeHandler } from "./node-handler.ts";
-export type { NodeUpgradeHandler } from "./node-handler.ts";
-
 // Removed from 0.2.x: createCrossWS, Caller, WSRequest, CrossWS

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,4 +22,8 @@ export type { ServerWithWSOptions, WSOptions } from "./server/_types.ts";
 export { createWebSocketProxy } from "./proxy.ts";
 export type { WebSocketProxyOptions } from "./proxy.ts";
 
+// Node handler
+export { fromNodeUpgradeHandler } from "./node-handler.ts";
+export type { NodeUpgradeHandler } from "./node-handler.ts";
+
 // Removed from 0.2.x: createCrossWS, Caller, WSRequest, CrossWS

--- a/src/node-handler.ts
+++ b/src/node-handler.ts
@@ -1,5 +1,6 @@
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
+import type { ServerRequest } from "srvx";
 import type { Hooks } from "./hooks.ts";
 
 /**
@@ -45,8 +46,12 @@ export function fromNodeUpgradeHandler(
 ): Partial<Hooks> {
   return {
     async upgrade(request) {
-      const node = (request as { runtime?: { node?: NodeUpgradeCtx } }).runtime
-        ?.node;
+      const node = (request as ServerRequest).runtime?.node as
+        | {
+            req: IncomingMessage;
+            upgrade?: { socket: Duplex; head: Buffer };
+          }
+        | undefined;
       if (!node?.upgrade) {
         throw new Error(
           "[crossws] `fromNodeUpgradeHandler` must be mounted via `crossws/server/node`.",
@@ -56,9 +61,4 @@ export function fromNodeUpgradeHandler(
       return { handled: true };
     },
   };
-}
-
-interface NodeUpgradeCtx {
-  req: IncomingMessage;
-  upgrade?: { socket: Duplex; head: Buffer };
 }

--- a/src/node-handler.ts
+++ b/src/node-handler.ts
@@ -40,7 +40,7 @@ export type NodeUpgradeHandler = (
  * @example
  * ```ts
  * import { WebSocketServer } from "ws";
- * import { fromNodeUpgradeHandler } from "crossws";
+ * import { fromNodeUpgradeHandler } from "crossws/adapters/node";
  * import { serve } from "crossws/server/node";
  *
  * const wss = new WebSocketServer({ noServer: true });

--- a/src/node-handler.ts
+++ b/src/node-handler.ts
@@ -1,0 +1,89 @@
+import type { IncomingMessage } from "node:http";
+import type { Duplex } from "node:stream";
+import type { Hooks } from "./hooks.ts";
+
+/**
+ * A Node.js-style WebSocket upgrade handler, matching the signature of
+ * `http.Server`'s `"upgrade"` event listener and libraries like
+ * [`ws`](https://github.com/websockets/ws).
+ *
+ * The handler takes ownership of `socket` for the remainder of the
+ * connection's lifetime.
+ */
+export type NodeUpgradeHandler = (
+  req: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+) => void | Promise<void>;
+
+/**
+ * Wrap a Node.js-style `(req, socket, head)` upgrade handler as a
+ * {@link Hooks} object so it can be plugged into crossws.
+ *
+ * This is useful when you have an existing Node.js WebSocket library
+ * (e.g. `ws`, `socket.io`, `express-ws`) that exposes a raw upgrade
+ * handler, and you want to route to it through crossws without giving
+ * up crossws's upgrade-time request handling.
+ *
+ * The returned hooks object only implements `upgrade`: the underlying
+ * handler takes full ownership of the socket, so crossws's other
+ * lifecycle hooks (`open`, `message`, `close`, `error`) are **not**
+ * invoked for connections routed through it. Manage the WebSocket
+ * lifecycle inside your own library as usual.
+ *
+ * > [!NOTE]
+ * > Only works on the Node.js runtime. The incoming request must carry
+ * > the srvx node runtime context (`request.runtime.node.req` and
+ * > `request.runtime.node.upgrade.{socket, head}`), which crossws's
+ * > node server plugin provides automatically.
+ *
+ * @example
+ * ```ts
+ * import { WebSocketServer } from "ws";
+ * import { fromNodeUpgradeHandler } from "crossws";
+ * import { serve } from "crossws/server/node";
+ *
+ * const wss = new WebSocketServer({ noServer: true });
+ * wss.on("connection", (ws) => {
+ *   ws.on("message", (data) => ws.send(data));
+ * });
+ *
+ * serve({
+ *   websocket: fromNodeUpgradeHandler((req, socket, head) => {
+ *     wss.handleUpgrade(req, socket, head, (ws) => {
+ *       wss.emit("connection", ws, req);
+ *     });
+ *   }),
+ *   fetch: () => new Response("ok"),
+ * });
+ * ```
+ */
+export function fromNodeUpgradeHandler(
+  handler: NodeUpgradeHandler,
+): Partial<Hooks> {
+  return {
+    async upgrade(request) {
+      const nodeCtx = (request as { runtime?: { node?: NodeUpgradeRuntime } })
+        .runtime?.node;
+      const req = nodeCtx?.req as IncomingMessage | undefined;
+      const upgrade = nodeCtx?.upgrade;
+      if (!req || !upgrade?.socket) {
+        throw new Error(
+          "[crossws] `fromNodeUpgradeHandler` requires a Node.js upgrade request. " +
+            "Make sure it is used via the crossws node server plugin so the " +
+            "request carries `runtime.node.upgrade.{socket, head}`.",
+        );
+      }
+      await handler(req, upgrade.socket, upgrade.head ?? Buffer.alloc(0));
+      return { handled: true };
+    },
+  };
+}
+
+interface NodeUpgradeRuntime {
+  req: IncomingMessage;
+  upgrade?: {
+    socket: Duplex;
+    head?: Buffer;
+  };
+}

--- a/src/node-handler.ts
+++ b/src/node-handler.ts
@@ -3,12 +3,7 @@ import type { Duplex } from "node:stream";
 import type { Hooks } from "./hooks.ts";
 
 /**
- * A Node.js-style WebSocket upgrade handler, matching the signature of
- * `http.Server`'s `"upgrade"` event listener and libraries like
- * [`ws`](https://github.com/websockets/ws).
- *
- * The handler takes ownership of `socket` for the remainder of the
- * connection's lifetime.
+ * A Node.js `(req, socket, head)` upgrade handler.
  */
 export type NodeUpgradeHandler = (
   req: IncomingMessage,
@@ -17,25 +12,12 @@ export type NodeUpgradeHandler = (
 ) => void | Promise<void>;
 
 /**
- * Wrap a Node.js-style `(req, socket, head)` upgrade handler as a
- * {@link Hooks} object so it can be plugged into crossws.
+ * Wrap a Node.js `(req, socket, head)` upgrade handler as a {@link Hooks}
+ * object that can be mounted via `crossws/server/node`.
  *
- * This is useful when you have an existing Node.js WebSocket library
- * (e.g. `ws`, `socket.io`, `express-ws`) that exposes a raw upgrade
- * handler, and you want to route to it through crossws without giving
- * up crossws's upgrade-time request handling.
- *
- * The returned hooks object only implements `upgrade`: the underlying
- * handler takes full ownership of the socket, so crossws's other
- * lifecycle hooks (`open`, `message`, `close`, `error`) are **not**
- * invoked for connections routed through it. Manage the WebSocket
- * lifecycle inside your own library as usual.
- *
- * > [!NOTE]
- * > Only works on the Node.js runtime. The incoming request must carry
- * > the srvx node runtime context (`request.runtime.node.req` and
- * > `request.runtime.node.upgrade.{socket, head}`), which crossws's
- * > node server plugin provides automatically.
+ * The wrapped handler takes ownership of the socket; crossws's other
+ * lifecycle hooks (`open`/`message`/`close`/`error`) are **not** invoked
+ * for connections routed through it.
  *
  * @example
  * ```ts
@@ -63,27 +45,20 @@ export function fromNodeUpgradeHandler(
 ): Partial<Hooks> {
   return {
     async upgrade(request) {
-      const nodeCtx = (request as { runtime?: { node?: NodeUpgradeRuntime } })
-        .runtime?.node;
-      const req = nodeCtx?.req as IncomingMessage | undefined;
-      const upgrade = nodeCtx?.upgrade;
-      if (!req || !upgrade?.socket) {
+      const node = (request as { runtime?: { node?: NodeUpgradeCtx } }).runtime
+        ?.node;
+      if (!node?.upgrade) {
         throw new Error(
-          "[crossws] `fromNodeUpgradeHandler` requires a Node.js upgrade request. " +
-            "Make sure it is used via the crossws node server plugin so the " +
-            "request carries `runtime.node.upgrade.{socket, head}`.",
+          "[crossws] `fromNodeUpgradeHandler` must be mounted via `crossws/server/node`.",
         );
       }
-      await handler(req, upgrade.socket, upgrade.head ?? Buffer.alloc(0));
+      await handler(node.req, node.upgrade.socket, node.upgrade.head);
       return { handled: true };
     },
   };
 }
 
-interface NodeUpgradeRuntime {
+interface NodeUpgradeCtx {
   req: IncomingMessage;
-  upgrade?: {
-    socket: Duplex;
-    head?: Buffer;
-  };
+  upgrade?: { socket: Duplex; head: Buffer };
 }

--- a/test/node-handler.test.ts
+++ b/test/node-handler.test.ts
@@ -1,0 +1,115 @@
+import { once } from "node:events";
+import { getRandomPort } from "get-port-please";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import { WebSocketServer } from "ws";
+import WebSocket from "ws";
+import { fromNodeUpgradeHandler } from "../src/node-handler.ts";
+import { serve } from "../src/server/node.ts";
+
+type ServeReturn = ReturnType<typeof serve>;
+
+let currentServer: ServeReturn | undefined;
+let currentWss: WebSocketServer | undefined;
+let unhandled: unknown[] = [];
+
+function onUnhandled(err: unknown) {
+  unhandled.push(err);
+}
+
+beforeEach(() => {
+  unhandled = [];
+  process.on("unhandledRejection", onUnhandled);
+  process.on("uncaughtException", onUnhandled);
+});
+
+afterEach(async () => {
+  process.off("unhandledRejection", onUnhandled);
+  process.off("uncaughtException", onUnhandled);
+  currentWss?.close();
+  await currentServer?.close(true);
+  currentServer = undefined;
+  currentWss = undefined;
+  // Give any stray async errors a tick to surface before asserting.
+  await new Promise((r) => setImmediate(r));
+  if (unhandled.length > 0) {
+    throw new AggregateError(
+      unhandled as Error[],
+      `Unexpected unhandled errors during test: ${unhandled
+        .map((e) => (e as Error)?.message ?? String(e))
+        .join("; ")}`,
+    );
+  }
+});
+
+test("fromNodeUpgradeHandler delegates upgrade to a ws.WebSocketServer", async () => {
+  const wss = new WebSocketServer({ noServer: true });
+  currentWss = wss;
+  const receivedOnUpstream: string[] = [];
+  wss.on("connection", (ws) => {
+    ws.on("message", (data) => {
+      receivedOnUpstream.push(data.toString());
+      ws.send(`echo:${data.toString()}`);
+    });
+  });
+
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => new Response("ok"),
+    websocket: fromNodeUpgradeHandler((req, socket, head) => {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit("connection", ws, req);
+      });
+    }),
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  await once(client, "open");
+  client.send("hello");
+  const [reply] = await once(client, "message");
+  expect(reply.toString()).toBe("echo:hello");
+  expect(receivedOnUpstream).toEqual(["hello"]);
+  client.close();
+  await once(client, "close");
+});
+
+test("fromNodeUpgradeHandler does not invoke node adapter's own handleUpgrade", async () => {
+  // If the handoff sentinel is ignored, the node adapter would try to run
+  // ws.handleUpgrade on a socket that the user's handler has already taken
+  // over — the client would see a connection failure or duplicate upgrade.
+  // This test catches that regression by asserting the upstream handler is
+  // the *only* thing that opens the WebSocket.
+  const wss = new WebSocketServer({ noServer: true });
+  currentWss = wss;
+  let upstreamOpens = 0;
+  wss.on("connection", (ws) => {
+    upstreamOpens++;
+    ws.on("message", (data) => ws.send(data));
+  });
+
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => new Response("ok"),
+    websocket: fromNodeUpgradeHandler((req, socket, head) => {
+      wss.handleUpgrade(req, socket, head, (ws) => {
+        wss.emit("connection", ws, req);
+      });
+    }),
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  await once(client, "open");
+  client.send("ping");
+  const [reply] = await once(client, "message");
+  expect(reply.toString()).toBe("ping");
+  expect(upstreamOpens).toBe(1);
+  client.close();
+  await once(client, "close");
+});


### PR DESCRIPTION
resolves #138

- Adds `fromNodeUpgradeHandler(handler)` — wraps a Node.js `(req, socket, head)` upgrade handler (e.g. from [`ws`](https://github.com/websockets/ws), `socket.io`, `express-ws`) as a crossws hooks object, so it can be mounted via `crossws/server/node` while delegating the socket to the underlying library.
- Pulls the real `req`/`socket`/`head` out of `request.runtime.node.{req, upgrade}` (exposed by srvx's `NodeRequest` from [src/server/node.ts:22](src/server/node.ts#L22)) — no polyfill needed, we just hand the triple to the user's handler.
- Adds a `handled?: boolean` sentinel to `Hooks.upgrade`'s return type. When the hook has taken ownership of the socket, the node adapter bails out before `wss.handleUpgrade` so the same socket isn't upgraded twice. Other runtimes ignore the flag.
- Exported from the `crossws/adapters/node` subpath (not the main entry), and documented in [docs/2.adapters/node.md](docs/2.adapters/node.md).

The wrapped handler takes ownership of the socket, so crossws's other lifecycle hooks (`open`/`message`/`close`/`error`) are **not** invoked for connections routed through it — the wrapped library manages the WebSocket lifecycle as usual.

## Example

```ts
import { WebSocketServer } from "ws";
import { fromNodeUpgradeHandler } from "crossws/adapters/node";
import { serve } from "crossws/server/node";

const wss = new WebSocketServer({ noServer: true });
wss.on("connection", (ws) => {
  ws.on("message", (data) => ws.send(data));
});

serve({
  fetch: () => new Response("ok"),
  websocket: fromNodeUpgradeHandler((req, socket, head) => {
    wss.handleUpgrade(req, socket, head, (ws) => {
      wss.emit("connection", ws, req);
    });
  }),
});
```

## Test plan

- [x] `pnpm vitest run test/node-handler.test.ts` — new regression tests pass.
- [x] Regression-first: temporarily removed the `handled` bailout in the node adapter and confirmed both tests fail hard (via an `unhandledRejection` guard) with `server.handleUpgrade() was called more than once with the same socket`.
- [x] `pnpm vitest run` — full suite (117 passed, 6 skipped).
- [x] `pnpm typecheck`.
- [x] `pnpm lint`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Delegate WebSocket upgrades to external Node.js handlers so third-party servers can own the socket and complete the upgrade.

* **Behavior Changes**
  * Connections delegated to external handlers bypass crossws lifecycle hooks (open, message, close, error).

* **Documentation**
  * New Node.js integration guide and Socket.IO integration section with usage patterns and runtime notes.

* **Examples**
  * Added a runnable Socket.IO example and browser client UI demonstrating combined transports.

* **Tests**
  * New tests validating delegated upgrade behavior and ensuring only the external handler performs the upgrade.

* **Chores**
  * Workspace updated to include examples in development tooling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->