### PR TITLE
fix(cloudflare): persist peer namespace in Durable Object attachment

### DIFF
--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -264,6 +264,7 @@ class CloudflareDurablePeer extends Peer<{
       state.u = request.url;
     }
     state.i = peer.id;
+    state.n = peer.namespace;
     setAttachedState(ws, state);
     return peer;
   }


### PR DESCRIPTION
## Problem

`AttachedState.n` is read in `_restore` (`namespace || state.n || ""`), but the namespace was never written back into the serialized attachment before `setAttachedState`. After Cloudflare WebSocket hibernation, restore can run without a fresh upgrade `namespace`, so `state.n` is missing and pub/sub / close paths can hit `getPeers` with an empty namespace.

## Change

Set `state.n = peer.namespace` before `setAttachedState` in `CloudflareDurablePeer._restore`, matching the documented `AttachedState.n` field.

Closes #187

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Cloudflare Durable Objects state persistence during peer restoration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->