### PR TITLE
feat: add publish  option and improve pubsub docs

### DIFF
--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -66,21 +66,21 @@ Peer's pubsub namespace.
 
 Send a message to the connected client.
 
-### `peer.subscribe(channel)`
+### `peer.subscribe(topic)`
 
-Join a broadcast channel.
-
-:read-more{to="/guide/pubsub"}
-
-### `peer.unsubscribe(channel)`
-
-Leave a broadcast channel.
+Join a broadcast topic.
 
 :read-more{to="/guide/pubsub"}
 
-### `peer.publish(channel, message)`
+### `peer.unsubscribe(topic)`
 
-Broadcast a message to the channel. The peer that the publish is called on itself is excluded from the broadcast.
+Leave a broadcast topic.
+
+:read-more{to="/guide/pubsub"}
+
+### `peer.publish(topic, message, { self?, compress? })`
+
+Broadcast a message to the topic. By default, the publishing peer is excluded from the broadcast. Pass `{ self: true }` to also deliver the message to the publishing peer when subscribed.
 
 :read-more{to="/guide/pubsub"}
 

--- a/docs/1.guide/5.pubsub.md
+++ b/docs/1.guide/5.pubsub.md
@@ -4,7 +4,32 @@ icon: simple-icons:googlepubsub
 
 # Pub / Sub
 
-crossws supports native pub-sub API integration. A [peer](/guide/peer) can be subscribed to a set of named channels using `peer.subscribe(<name>)`. Messages can be published to a channel using `peer.publish(<name>, <message>)`. When publishing to a channel, the peer that does the publish is excluded from the broadcast so it won't receive it's own message.
+crossws supports native pub-sub API integration. A [peer](/guide/peer) can be subscribed to a set of named topics using `peer.subscribe(<name>)`. Messages can be published to a topic using `peer.publish(<name>, <message>)`.
+
+By default, the peer that calls `publish` is **excluded** from the broadcast and will not receive its own message. Pass `{ self: true }` to include the publishing peer when it is subscribed to the topic:
+
+```js
+peer.publish("chat", message, { self: true });
+```
+
+> [!NOTE]
+> Some runtimes (such as Bun) natively exclude the publisher from pub/sub. crossws adds an explicit `send()` when `{ self: true }` is used so behavior is consistent across adapters.
+
+## Global publish
+
+Each adapter instance also exposes a global `publish(topic, message, options?)` helper (available since v0.4) that broadcasts to all connected peers subscribed to the topic across namespaces (or a specific namespace via `options.namespace`):
+
+```js
+const ws = nodeAdapter({ hooks });
+
+// Publish to all peers subscribed to "chat" in every namespace
+ws.publish("chat", "Hello everyone!");
+
+// Limit to a specific namespace
+ws.publish("chat", "Hello namespace!", { namespace: "/api" });
+```
+
+## Example
 
 ```js
 import { defineHooks } from "crossws";
@@ -19,7 +44,7 @@ const hooks = defineHooks({
     // Send welcome to the new client
     peer.send("Welcome to the server!");
 
-    // Join new client to the "chat" channel
+    // Join new client to the "chat" topic
     peer.subscribe("chat");
 
     // Notify every other connected client

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,5 +1,5 @@
 import type { Hooks, ResolveHooks } from "./hooks.ts";
-import type { Peer } from "./peer.ts";
+import type { Peer, PublishOptions } from "./peer.ts";
 
 export function adapterUtils(globalPeers: Map<string, Set<Peer>>): AdapterInstance {
   return {
@@ -46,7 +46,7 @@ export interface AdapterInstance {
   readonly publish: (
     topic: string,
     data: unknown,
-    options?: { compress?: boolean; namespace?: string },
+    options?: PublishOptions & { namespace?: string },
   ) => void;
 }
 

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -4,7 +4,7 @@ import { toBufferLike } from "../utils.ts";
 import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
-import { Peer, type PeerContext } from "../peer.ts";
+import { Peer, type PeerContext, type PublishOptions } from "../peer.ts";
 
 // --- types ---
 
@@ -113,8 +113,12 @@ class BunPeer extends Peer<{
     return this._internal.ws.send(toBufferLike(data), options?.compress);
   }
 
-  publish(topic: string, data: unknown, options?: { compress?: boolean }): number {
-    return this._internal.ws.publish(topic, toBufferLike(data), options?.compress);
+  publish(topic: string, data: unknown, options?: PublishOptions): number {
+    const result = this._internal.ws.publish(topic, toBufferLike(data), options?.compress);
+    if (options?.self && this.topics.has(topic)) {
+      this.send(data, options);
+    }
+    return result;
   }
 
   override subscribe(topic: string): void {

--- a/src/adapters/bunny.ts
+++ b/src/adapters/bunny.ts
@@ -1,10 +1,10 @@
 import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
-import { toBufferLike } from "../utils.ts";
+import { toBufferLike, shouldPublishToPeer } from "../utils.ts";
 import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
-import { Peer, type PeerContext } from "../peer.ts";
+import { Peer, type PeerContext, type PublishOptions } from "../peer.ts";
 
 // --- types ---
 
@@ -134,10 +134,10 @@ class BunnyPeer extends Peer<{
     return this._internal.ws.send(toBufferLike(data));
   }
 
-  publish(topic: string, data: unknown) {
+  publish(topic: string, data: unknown, options?: PublishOptions) {
     const dataBuff = toBufferLike(data);
     for (const peer of this._internal.peers) {
-      if (peer !== this && peer._topics.has(topic)) {
+      if (shouldPublishToPeer(this, peer, topic, options)) {
         peer._internal.ws.send(dataBuff);
       }
     }

--- a/src/adapters/cloudflare.ts
+++ b/src/adapters/cloudflare.ts
@@ -7,7 +7,7 @@ import { toBufferLike } from "../utils.ts";
 import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
-import { Peer, type PeerContext } from "../peer.ts";
+import { Peer, type PeerContext, type PublishOptions } from "../peer.ts";
 import { StubRequest } from "../_request.ts";
 import { WSError } from "../error.ts";
 
@@ -219,14 +219,14 @@ class CloudflareDurablePeer extends Peer<{
     setAttachedState(this._internal.ws, state);
   }
 
-  publish(topic: string, data: unknown): void {
+  publish(topic: string, data: unknown, options?: PublishOptions): void {
     const websockets = this.#getwebsockets();
-    if (websockets.length < 2 /* 1 is self! */) {
+    if (websockets.length < 2 && !options?.self) {
       return;
     }
     const dataBuff = toBufferLike(data);
     for (const ws of websockets) {
-      if (ws === this._internal.ws) {
+      if (ws === this._internal.ws && !options?.self) {
         continue;
       }
       const state = getAttachedState(ws);

--- a/src/adapters/deno.ts
+++ b/src/adapters/deno.ts
@@ -1,10 +1,10 @@
 import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
-import { toBufferLike } from "../utils.ts";
+import { toBufferLike, shouldPublishToPeer } from "../utils.ts";
 import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
-import { Peer, type PeerContext } from "../peer.ts";
+import { Peer, type PeerContext, type PublishOptions } from "../peer.ts";
 
 // --- types ---
 
@@ -96,10 +96,10 @@ class DenoPeer extends Peer<{
     return this._internal.ws.send(toBufferLike(data));
   }
 
-  publish(topic: string, data: unknown) {
+  publish(topic: string, data: unknown, options?: PublishOptions) {
     const dataBuff = toBufferLike(data);
     for (const peer of this._internal.peers) {
-      if (peer !== this && peer._topics.has(topic)) {
+      if (shouldPublishToPeer(this, peer, topic, options)) {
         peer._internal.ws.send(dataBuff);
       }
     }

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -1,10 +1,10 @@
 import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
-import { toBufferLike } from "../utils.ts";
+import { toBufferLike, shouldPublishToPeer } from "../utils.ts";
 import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
 import { WSError } from "../error.ts";
-import { Peer, type PeerContext } from "../peer.ts";
+import { Peer, type PeerContext, type PublishOptions } from "../peer.ts";
 
 import type { IncomingMessage } from "node:http";
 import type { Duplex } from "node:stream";
@@ -169,7 +169,7 @@ class NodePeer extends Peer<{
     return 0;
   }
 
-  publish(topic: string, data: unknown, options?: { compress?: boolean }): void {
+  publish(topic: string, data: unknown, options?: PublishOptions): void {
     const dataBuff = toBufferLike(data);
     const isBinary = typeof data !== "string";
     const sendOptions = {
@@ -178,7 +178,7 @@ class NodePeer extends Peer<{
       ...options,
     };
     for (const peer of this._internal.peers) {
-      if (peer !== this && peer._topics.has(topic)) {
+      if (shouldPublishToPeer(this, peer, topic, options)) {
         peer._internal.ws.send(dataBuff, sendOptions);
       }
     }

--- a/src/adapters/sse.ts
+++ b/src/adapters/sse.ts
@@ -1,10 +1,10 @@
 import type { AdapterOptions, AdapterInstance, Adapter } from "../adapter.ts";
 import type * as web from "../../types/web.ts";
-import { toString } from "../utils.ts";
+import { toString, shouldPublishToPeer } from "../utils.ts";
 import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
-import { Peer, type PeerContext } from "../peer.ts";
+import { Peer, type PeerContext, type PublishOptions } from "../peer.ts";
 
 // --- types ---
 
@@ -138,10 +138,10 @@ class SSEPeer extends Peer<{
     return 0;
   }
 
-  publish(topic: string, data: unknown) {
+  publish(topic: string, data: unknown, options?: PublishOptions) {
     const dataBuff = toString(data);
     for (const peer of this._internal.peers) {
-      if (peer !== this && peer._topics.has(topic)) {
+      if (shouldPublishToPeer(this, peer, topic, options)) {
         peer._sendEvent("message", dataBuff);
       }
     }

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -5,7 +5,7 @@ import { toBufferLike } from "../utils.ts";
 import { adapterUtils, getPeers } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
-import { Peer, type PeerContext } from "../peer.ts";
+import { Peer, type PeerContext, type PublishOptions } from "../peer.ts";
 import { StubRequest } from "../_request.ts";
 
 // --- types ---
@@ -189,10 +189,13 @@ class UWSPeer extends Peer<{
     this._internal.uws.unsubscribe(topic);
   }
 
-  publish(topic: string, message: string, options?: { compress?: boolean }) {
+  publish(topic: string, message: string, options?: PublishOptions) {
     const data = toBufferLike(message);
     const isBinary = typeof data !== "string";
     this._internal.uws.publish(topic, data, isBinary, options?.compress);
+    if (options?.self && this.topics.has(topic)) {
+      this.send(message, options);
+    }
     return 0;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export type { Adapter, AdapterInstance, AdapterOptions } from "./adapter.ts";
 export type { Message } from "./message.ts";
 
 // Peer
-export type { Peer, PeerContext, AdapterInternal } from "./peer.ts";
+export type { Peer, PeerContext, AdapterInternal, PublishOptions } from "./peer.ts";
 
 // Error
 export type { WSError } from "./error.ts";

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -3,6 +3,12 @@ import { kNodeInspect } from "./utils.ts";
 
 export interface PeerContext extends Record<string, unknown> {}
 
+export interface PublishOptions {
+  /** When `true`, include the publishing peer if subscribed (default: `false`). */
+  self?: boolean;
+  compress?: boolean;
+}
+
 export interface AdapterInternal {
   ws: unknown;
   request: Request;
@@ -98,8 +104,8 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   /** Send a message to the peer. */
   abstract send(data: unknown, options?: { compress?: boolean }): number | void | undefined;
 
-  /** Send message to subscribes of topic */
-  abstract publish(topic: string, data: unknown, options?: { compress?: boolean }): void;
+  /** Send message to subscribers of topic */
+  abstract publish(topic: string, data: unknown, options?: PublishOptions): void;
 
   // --- inspect ---
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,15 @@
+import type { PublishOptions, Peer } from "./peer.ts";
+
 type BufferLike = string | Buffer | Uint8Array | ArrayBuffer;
+
+export function shouldPublishToPeer(
+  publisher: Peer,
+  peer: Peer,
+  topic: string,
+  options?: PublishOptions,
+): boolean {
+  return peer.topics.has(topic) && (options?.self === true || peer !== publisher);
+}
 
 // https://nodejs.org/api/util.html#utilinspectcustom
 export const kNodeInspect: unique symbol = /*#__PURE__*/ Symbol.for("nodejs.util.inspect.custom");

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -104,5 +104,17 @@ export function handleDemoRoutes(ws: AdapterInstance, request: Request): Respons
     const message = url.searchParams.get("message") || "";
     ws.publish(topic, message);
     return new Response("published");
+  } else if (url.pathname === "/publish-self") {
+    const topic = url.searchParams.get("topic") || "";
+    const message = url.searchParams.get("message") || "";
+    for (const peers of ws.peers.values()) {
+      for (const peer of peers) {
+        if (peer.topics.has(topic)) {
+          peer.publish(topic, message, { self: true });
+          return new Response("published");
+        }
+      }
+    }
+    return new Response("no peer subscribed", { status: 404 });
   }
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -183,4 +183,13 @@ export function wsTests(getURL: () => string, opts: WSTestOpts): void {
       expect(await ws2.next()).toBe("ping");
     },
   );
+
+  test.skipIf(opts.adapter === "cloudflare" /* durable only */)(
+    "publish with self: true includes publisher",
+    async () => {
+      const ws1 = await wsConnect(getURL(), { skip: 1 });
+      await fetch(getURL().replace("ws", "http") + `publish-self?topic=chat&message=echo-self`);
+      expect(await ws1.next()).toBe("echo-self");
+    },
+  );
 }


### PR DESCRIPTION
## Summary

- Add `{ self: true }` option to `peer.publish()` so the publishing peer can receive its own message when subscribed
- For runtimes with native pub/sub that exclude self (Bun, μWebSockets), explicitly `send()` when `{ self: true }` is set
- Improve pub/sub documentation: clarify default self-exclusion, unify **topic** terminology, and document global `adapter.publish()`

Addresses #172

## Test plan

- [x] Added integration test: `publish with self: true includes publisher`
- [x] `pnpm vitest run test/adapters/node.test.ts` passes (16/16)
- [x] `pnpm lint` and `pnpm typecheck` pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Replaced "channel" terminology with "topic" in API documentation
  * Expanded `publish` method documentation with new optional parameters

* **New Features**
  * Added `self` option enabling peers to receive their own published messages
  * Added `compress` option for optional message compression
  * Introduced global `publish` helper for broadcasting across all connected peers and namespaces

* **Tests**
  * Added test for self-delivery functionality

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/crossws/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->