### PR TITLE
feat(proxy): allow `forwardProtocol` to rewrite the upstream subprotocol

### DIFF
--- a/docs/1.guide/7.proxy.md
+++ b/docs/1.guide/7.proxy.md
@@ -90,6 +90,40 @@ createWebSocketProxy({
 > [!WARNING]
 > The proxy commits to a subprotocol in the upgrade response before the upstream connection is established. If the upstream ultimately picks a different subprotocol (or rejects), the client will still see the one the proxy promised. Only keep `forwardProtocol` enabled when the upstream is known to accept the same subprotocols the client negotiates.
 
+### Rewriting the upstream subprotocol
+
+`forwardProtocol` can present a _different_ subprotocol to the upstream than the client offered — useful when a client re-labels a token to pass an intermediary and the proxy must restore the real token when dialing the origin. Pick the simplest form that fits:
+
+```ts
+// 1. Fixed value — the upstream always expects one known subprotocol.
+createWebSocketProxy({
+  target: "wss://backend.example.com",
+  forwardProtocol: "vite-hmr",
+});
+
+// 2. Rewrite map — swap specific client tokens, pass the rest through.
+createWebSocketProxy({
+  target: "wss://backend.example.com",
+  forwardProtocol: { "proxied-vite-hmr": "vite-hmr" },
+});
+
+// 3. Function — when the rewrite depends on more than the token value.
+createWebSocketProxy({
+  target: "wss://backend.example.com",
+  forwardProtocol: (peer) =>
+    (peer.request.headers.get("sec-websocket-protocol") ?? "")
+      .split(",")
+      .map((p) => p.trim())
+      .filter(Boolean)
+      .map((p) => (p.startsWith("proxied-") ? p.slice("proxied-".length) : p)),
+});
+```
+
+The function receives the [`Peer`](/guide/peer) and returns a `string`, an array of strings, or `undefined` to offer none.
+
+> [!NOTE]
+> These forms control only what is offered to the **upstream**. The subprotocol echoed back to the **client** stays the first token the client offered — per RFC 6455 the selected subprotocol must be one the client proposed, so echoing a rewritten value (which the client may not have offered) would make browsers fail the connection.
+
 ## Custom WebSocket constructor
 
 Pass a `WebSocket` constructor via options to override the global — useful on Node.js < 22, to plug in a different client implementation, or to stub the upstream in tests.
@@ -146,7 +180,13 @@ const hooks = createWebSocketProxy({
 Accepts either a target URL (`string` or `URL`), a resolver function, or an options object:
 
 - **`target`** — `string | URL | (peer: Peer) => string | URL`. The upstream WebSocket URL, or a function that resolves it per peer. The proxy does not enforce a scheme allowlist; any URL the configured `WebSocket` constructor accepts (including `ws+unix:` with `ws`) works. See the [SSRF warning](#dynamic-target) before using a dynamic resolver.
-- **`forwardProtocol`** — `boolean` (default `true`). When enabled, the client's `sec-websocket-protocol` header is forwarded to the upstream and echoed back in the upgrade response. Values that are not valid RFC 7230 tokens are dropped.
+- **`forwardProtocol`** — `boolean | string | string[] | Record<string, string> | (peer: Peer) => string | string[] | undefined` (default `true`). Controls the subprotocol(s) offered to the upstream:
+  - `true` forwards the client's `sec-websocket-protocol` header verbatim; `false` offers none.
+  - a `string`/`string[]` offers a fixed value upstream regardless of the client.
+  - a `Record<string, string>` rewrites matching client tokens to their mapped values, passing unmapped tokens through.
+  - a function resolves the value per peer.
+
+  See [rewriting the upstream subprotocol](#rewriting-the-upstream-subprotocol). In all cases the value echoed back to the client is the first client-offered token (RFC 6455), and values that are not valid RFC 7230 tokens are dropped from the echo.
 - **`headers`** — `HeadersInit | (peer: Peer) => HeadersInit`. Extra headers to send on the upstream handshake. Only honored when a custom `WebSocket` constructor that accepts a third options argument is supplied — the WHATWG global ignores it.
 - **`maxBufferSize`** — `number` (default `1048576`, i.e. 1 MiB). Maximum number of bytes buffered per peer while the upstream is still connecting. String frames are accounted at their UTF-8 worst case (3 bytes per UTF-16 code unit) to avoid undercounting multi-byte content. When exceeded, the peer is closed with code `1009` (Message Too Big). Set to `0` to disable.
 - **`connectTimeout`** — `number` (default `10000`). Milliseconds to wait for the upstream WebSocket handshake to complete. If exceeded, the peer is closed with code `1011`. Set to `0` to disable.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -142,12 +142,12 @@ export function createWebSocketProxy(
       }
       // Accept the first requested subprotocol so the upgrade handshake
       // echoes a value the client expects. Upstream must support it too.
-      const accepted = reqProtocol.split(",")[0]!.trim();
+      const accepted = _splitProtocolHeader(reqProtocol)[0];
       // Defense-in-depth: only echo RFC 7230 tokens. The Fetch `Headers`
       // API already rejects CRLF, but restricting to the subprotocol
       // grammar ensures no other client-controlled bytes can land in a
       // response header — even under buggy or custom header writers.
-      if (!TOKEN_RE.test(accepted)) {
+      if (!accepted || !TOKEN_RE.test(accepted)) {
         return;
       }
       return { headers: { "sec-websocket-protocol": accepted } };
@@ -352,34 +352,45 @@ export function _resolveProtocols(
 
   const header = peer.request?.headers.get("sec-websocket-protocol");
   if (!header) return;
-  const offered = header
-    .split(",")
-    .map((p) => p.trim())
-    .filter(Boolean);
+  const offered = _splitProtocolHeader(header);
 
   // Rewrite map — swap mapped client tokens, pass the rest through verbatim.
   // `hasOwnProperty` guards against inherited keys (e.g. `toString`) being
   // treated as rewrite rules.
   if (forwardProtocol && typeof forwardProtocol === "object") {
+    const map = forwardProtocol;
     return _normalizeProtocols(
-      offered.map((p) =>
-        Object.prototype.hasOwnProperty.call(forwardProtocol, p) ? forwardProtocol[p]! : p,
-      ),
+      offered.map((p) => (Object.prototype.hasOwnProperty.call(map, p) ? map[p] : p)),
     );
   }
 
   // `true` / `undefined` — forward the client header verbatim.
-  return offered.length > 0 ? offered : undefined;
+  return _normalizeProtocols(offered);
 }
 
-// Coerce a resolver/static value into a clean token list, or `undefined` to
-// offer no subprotocol. Trims, drops empties, and tolerates `null`/`void`.
-function _normalizeProtocols(value: string | string[] | undefined | void): string[] | undefined {
+// Split a `sec-websocket-protocol` header value into trimmed, non-empty tokens.
+function _splitProtocolHeader(header: string): string[] {
+  return header
+    .split(",")
+    .map((p) => p.trim())
+    .filter(Boolean);
+}
+
+// Coerce a resolver/static/rewritten value into a clean token list, or
+// `undefined` to offer no subprotocol. Drops nullish/empty entries, trims, and
+// de-duplicates — the WHATWG `WebSocket` constructor rejects a protocols list
+// containing duplicates or blank tokens, so a rewrite map that collapses
+// several client tokens onto one upstream value must not produce repeats.
+function _normalizeProtocols(
+  value: string | ReadonlyArray<string | undefined | null> | undefined | void,
+): string[] | undefined {
   if (value == null) return;
   const list = (Array.isArray(value) ? value : [value])
+    .filter((p) => p != null)
     .map((p) => String(p).trim())
     .filter(Boolean);
-  return list.length > 0 ? list : undefined;
+  const deduped = [...new Set(list)];
+  return deduped.length > 0 ? deduped : undefined;
 }
 
 function _safeClose(peer: Peer, code?: number, reason?: string): void {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,11 +23,31 @@ export interface WebSocketProxyOptions {
   target: string | URL | ((peer: Peer) => string | URL);
 
   /**
-   * Forward the client's `sec-websocket-protocol` header to the upstream.
+   * Subprotocol(s) to offer the upstream during the handshake.
+   *
+   * - `true` (default) — forward the client's `sec-websocket-protocol` verbatim.
+   * - `false` — offer no subprotocol upstream.
+   * - `string` / `string[]` — offer a fixed subprotocol (or list) upstream,
+   *   regardless of what the client requested.
+   * - `Record<string, string>` — rewrite map applied to the client's offered
+   *   tokens: a token that matches a key is swapped for its value; tokens not
+   *   in the map are forwarded verbatim.
+   * - function — resolve the upstream subprotocol(s) per {@link Peer}. Return a
+   *   string, an array of strings, or `undefined` to offer none. Useful when the
+   *   rewrite depends on more than the token value alone.
+   *
+   * Note: this controls only what is offered to the *upstream*. The subprotocol
+   * echoed back to the *client* remains the first token the client offered (per
+   * RFC 6455, the selected protocol must be one the client proposed).
    *
    * @default true
    */
-  forwardProtocol?: boolean;
+  forwardProtocol?:
+    | boolean
+    | string
+    | string[]
+    | Record<string, string>
+    | ((peer: Peer) => string | string[] | undefined | void);
 
   /**
    * Maximum number of bytes buffered per peer while the upstream connection
@@ -312,14 +332,54 @@ function _resolveWsOptions(
   return { headers: resolved };
 }
 
-function _resolveProtocols(peer: Peer, forwardProtocol: boolean | undefined): string[] | undefined {
+/** @internal exported for tests */
+export function _resolveProtocols(
+  peer: Peer,
+  forwardProtocol: WebSocketProxyOptions["forwardProtocol"],
+): string[] | undefined {
   if (forwardProtocol === false) return;
+
+  // Per-peer resolver — fully dynamic.
+  if (typeof forwardProtocol === "function") {
+    return _normalizeProtocols(forwardProtocol(peer));
+  }
+
+  // Static value — offer a fixed subprotocol (or list) upstream, regardless
+  // of what the client requested.
+  if (typeof forwardProtocol === "string" || Array.isArray(forwardProtocol)) {
+    return _normalizeProtocols(forwardProtocol);
+  }
+
   const header = peer.request?.headers.get("sec-websocket-protocol");
   if (!header) return;
-  return header
+  const offered = header
     .split(",")
     .map((p) => p.trim())
     .filter(Boolean);
+
+  // Rewrite map — swap mapped client tokens, pass the rest through verbatim.
+  // `hasOwnProperty` guards against inherited keys (e.g. `toString`) being
+  // treated as rewrite rules.
+  if (forwardProtocol && typeof forwardProtocol === "object") {
+    return _normalizeProtocols(
+      offered.map((p) =>
+        Object.prototype.hasOwnProperty.call(forwardProtocol, p) ? forwardProtocol[p]! : p,
+      ),
+    );
+  }
+
+  // `true` / `undefined` — forward the client header verbatim.
+  return offered.length > 0 ? offered : undefined;
+}
+
+// Coerce a resolver/static value into a clean token list, or `undefined` to
+// offer no subprotocol. Trims, drops empties, and tolerates `null`/`void`.
+function _normalizeProtocols(value: string | string[] | undefined | void): string[] | undefined {
+  if (value == null) return;
+  const list = (Array.isArray(value) ? value : [value])
+    .map((p) => String(p).trim())
+    .filter(Boolean);
+  return list.length > 0 ? list : undefined;
 }
 
 function _safeClose(peer: Peer, code?: number, reason?: string): void {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -3,7 +3,7 @@ import { createServer, Server } from "node:http";
 import { getRandomPort, waitForPort } from "get-port-please";
 import nodeAdapter from "../src/adapters/node.ts";
 import { createWebSocketProxy, defineHooks } from "../src/index.ts";
-import { _normalizeOutgoingCode, _remapIncomingCode } from "../src/proxy.ts";
+import { _normalizeOutgoingCode, _remapIncomingCode, _resolveProtocols } from "../src/proxy.ts";
 import { wsConnect } from "./_utils.ts";
 
 describe("createWebSocketProxy", () => {
@@ -380,5 +380,100 @@ describe("createWebSocketProxy internals", () => {
     expect(_remapIncomingCode(1006)).toBe(1011);
     expect(_remapIncomingCode(1015)).toBe(1011);
     expect(_remapIncomingCode(4321)).toBe(4321);
+  });
+
+  test("_resolveProtocols resolves boolean and function forms", () => {
+    const peerWith = (protocol?: string) =>
+      ({
+        request: new Request(
+          "http://localhost/",
+          protocol ? { headers: { "sec-websocket-protocol": protocol } } : undefined,
+        ),
+      }) as never;
+
+    // boolean: undefined/true forwards the client header verbatim
+    expect(_resolveProtocols(peerWith("a, b"), undefined)).toEqual(["a", "b"]);
+    expect(_resolveProtocols(peerWith("a, b"), true)).toEqual(["a", "b"]);
+    expect(_resolveProtocols(peerWith(), true)).toBeUndefined();
+
+    // boolean false: offer nothing
+    expect(_resolveProtocols(peerWith("a, b"), false)).toBeUndefined();
+
+    // function: string, array, undefined
+    expect(_resolveProtocols(peerWith("a"), () => "x")).toEqual(["x"]);
+    expect(_resolveProtocols(peerWith("a"), () => ["x", " y "])).toEqual(["x", "y"]);
+    expect(_resolveProtocols(peerWith("a"), () => undefined)).toBeUndefined();
+    expect(_resolveProtocols(peerWith("a"), () => [])).toBeUndefined();
+    expect(_resolveProtocols(peerWith("a"), () => ["", "  "])).toBeUndefined();
+
+    // function: re-label client token for the upstream
+    const stripPrefix = (peer: { request: Request }) =>
+      (peer.request.headers.get("sec-websocket-protocol") ?? "")
+        .split(",")
+        .map((p) => p.trim())
+        .filter(Boolean)
+        .map((p) => (p.startsWith("x-test-") ? p.slice("x-test-".length) : p));
+    expect(_resolveProtocols(peerWith("x-test-vite-hmr"), stripPrefix as never)).toEqual([
+      "vite-hmr",
+    ]);
+
+    // static string / string[]: offer a fixed value regardless of the client
+    expect(_resolveProtocols(peerWith("x-test-vite-hmr"), "vite-hmr")).toEqual(["vite-hmr"]);
+    expect(_resolveProtocols(peerWith(), "vite-hmr")).toEqual(["vite-hmr"]);
+    expect(_resolveProtocols(peerWith("a"), [" v1 ", "v2", ""])).toEqual(["v1", "v2"]);
+    expect(_resolveProtocols(peerWith("a"), "  ")).toBeUndefined();
+
+    // rewrite map: swap mapped tokens, pass the rest through verbatim
+    expect(
+      _resolveProtocols(peerWith("pspace-proxied-vite-hmr, chat"), {
+        "pspace-proxied-vite-hmr": "vite-hmr",
+      }),
+    ).toEqual(["vite-hmr", "chat"]);
+    // map with no matching client tokens forwards them unchanged
+    expect(_resolveProtocols(peerWith("chat"), { other: "x" })).toEqual(["chat"]);
+    // map ignores inherited keys (no client header → nothing to offer)
+    expect(_resolveProtocols(peerWith(), { a: "b" })).toBeUndefined();
+    expect(_resolveProtocols(peerWith("toString"), {})).toEqual(["toString"]);
+  });
+
+  test("forwardProtocol resolver feeds the upstream constructor's protocols argument", () => {
+    const calls: Array<{ protocols: unknown }> = [];
+    class StubWS extends EventTarget {
+      binaryType = "arraybuffer";
+      readyState = 0;
+      constructor(_url: unknown, protocols?: unknown) {
+        super();
+        calls.push({ protocols });
+      }
+      send(): void {}
+      close(): void {}
+    }
+    const hooks = createWebSocketProxy({
+      target: "ws://upstream.invalid/",
+      WebSocket: StubWS as unknown as typeof WebSocket,
+      connectTimeout: 0,
+      forwardProtocol: (peer) =>
+        (peer.request?.headers.get("sec-websocket-protocol") ?? "")
+          .split(",")
+          .map((p) => p.trim())
+          .filter(Boolean)
+          .map((p) => (p.startsWith("x-test-") ? p.slice("x-test-".length) : p)),
+    });
+    const peer = {
+      id: "p-proto",
+      request: new Request("http://localhost/", {
+        headers: { "sec-websocket-protocol": "x-test-vite-hmr" },
+      }),
+      close() {},
+      send() {},
+    };
+    hooks.open?.(peer as never);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.protocols).toEqual(["vite-hmr"]);
+
+    // The client-facing echo stays the client-offered token, not the resolved one.
+    expect(hooks.upgrade?.(peer.request)).toMatchObject({
+      headers: { "sec-websocket-protocol": "x-test-vite-hmr" },
+    });
   });
 });

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -434,6 +434,22 @@ describe("createWebSocketProxy internals", () => {
     // map ignores inherited keys (no client header → nothing to offer)
     expect(_resolveProtocols(peerWith(), { a: "b" })).toBeUndefined();
     expect(_resolveProtocols(peerWith("toString"), {})).toEqual(["toString"]);
+
+    // de-dupe: a rewrite map collapsing several tokens onto one value, or a
+    // client offering duplicates, must not produce repeats (the WHATWG
+    // WebSocket constructor rejects a protocols list with duplicates).
+    expect(_resolveProtocols(peerWith("proxied-hmr, hmr"), { "proxied-hmr": "hmr" })).toEqual([
+      "hmr",
+    ]);
+    expect(_resolveProtocols(peerWith("a, a, b"), true)).toEqual(["a", "b"]);
+    expect(_resolveProtocols(peerWith("a"), () => ["x", "x"])).toEqual(["x"]);
+
+    // nullish entries inside a returned/mapped list are dropped, not coerced
+    // to the literal strings "null"/"undefined".
+    expect(_resolveProtocols(peerWith("a"), () => ["vite-hmr", null as never])).toEqual([
+      "vite-hmr",
+    ]);
+    expect(_resolveProtocols(peerWith("a, b"), { a: undefined as never })).toEqual(["b"]);
   });
 
   test("forwardProtocol resolver feeds the upstream constructor's protocols argument", () => {


### PR DESCRIPTION
## Summary

`createWebSocketProxy` could only forward the client's `Sec-WebSocket-Protocol` **verbatim** (`forwardProtocol: true`) or **not at all** (`false`). Reverse proxies that must present a *different* subprotocol upstream than the client offered — e.g. re-labelling a token to pass an intermediary, then restoring the real token for the origin — had no hook for it, and had to abandon the util and reimplement all of its hooks (losing its buffering, connect-timeout, and close-code remapping in the process).

`forwardProtocol` now accepts three new forms in addition to the boolean:

```ts
forwardProtocol: "vite-hmr"                          // fixed value upstream
forwardProtocol: ["v1", "v2"]                         // fixed list
forwardProtocol: { "proxied-vite-hmr": "vite-hmr" }   // rewrite map (unmapped pass through)
forwardProtocol: (peer) => string | string[] | undefined  // dynamic resolver
```

Boolean behavior is unchanged. The subprotocol **echoed back to the client** stays the first client-offered token (RFC 6455 requires the selected protocol to be one the client proposed), so only the upstream offer is affected.

### Motivating case

A Nitro app reverse-proxies a Vite dev server. Vite's HMR client connects with subprotocol `vite-hmr`, but the outer host ignores any upgrade whose subprotocol starts with `vite-`. The client re-labels the token to get past the intermediary; the proxy must strip the prefix and offer the real `vite-hmr` upstream. That whole reimplementation now collapses to one line:

```ts
createWebSocketProxy({ target, forwardProtocol: "vite-hmr" });
```

## Implementation

- Widened `WebSocketProxyOptions.forwardProtocol` to `boolean | string | string[] | Record<string, string> | ((peer) => string | string[] | undefined | void)`.
- `_resolveProtocols` branches over the forms; rewrite-map lookups use `hasOwnProperty` so inherited keys (`toString`, etc.) aren't treated as rules. A shared `_normalizeProtocols` helper trims, drops empties, and tolerates `null`/empty (offer nothing).
- The `upgrade` echo is untouched — its `=== false` guard means every other form still echoes the client's own token.

## Testing

- Unit coverage for boolean / string / array / map / function forms (including no-client-header and inherited-key cases). 21 proxy tests, **119 total — all pass**; typecheck and lint clean.
- End-to-end verified against an upstream that only accepts `vite-hmr`: both the static-string and rewrite-map proxies translate a re-labelled client token and the upstream sees `vite-hmr`, while the client handshake still completes with `101`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `forwardProtocol` now accepts fixed strings, arrays, rewrite maps, or per-connection functions to control upstream subprotocol offers; unmapped tokens pass through and duplicates/empty entries are cleaned.

* **Documentation**
  * Added guide section showing rewrite usage and examples; clarifies that the client-seen subprotocol remains the first client-offered token and invalid tokens are handled gracefully.

* **Tests**
  * Added unit tests covering all `forwardProtocol` forms and behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/h3js/crossws/pull/190?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->