### PR TITLE
fix(node): publish non-string payloads as text frames

### DIFF
--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -171,7 +171,10 @@ class NodePeer extends Peer<{
 
   publish(topic: string, data: unknown, options?: { compress?: boolean }): void {
     const dataBuff = toBufferLike(data);
-    const isBinary = typeof data !== "string";
+    // Derive `isBinary` from the serialized buffer, not the raw input: a plain
+    // object/number is normalized to a JSON/text string by `toBufferLike`, so it
+    // must be sent as text. (Matches the uWS adapter's handling.)
+    const isBinary = typeof dataBuff !== "string";
     const sendOptions = {
       compress: options?.compress,
       binary: isBinary,

--- a/test/adapters/node.test.ts
+++ b/test/adapters/node.test.ts
@@ -2,8 +2,10 @@ import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { createServer, Server } from "node:http";
 import { getRandomPort, waitForPort } from "get-port-please";
 import nodeAdapter from "../../src/adapters/node";
+import { defineHooks } from "../../src/index";
 import { createDemo } from "../fixture/_shared";
 import { wsTests } from "../tests";
+import { wsConnect } from "../_utils";
 
 describe("node", () => {
   let server: Server;
@@ -55,5 +57,60 @@ describe("node", () => {
         expect(peer.websocket.readyState).toBe(2 /* CLOSING */);
       }
     }
+  });
+});
+
+// Regression: `NodePeer._publish` derived `isBinary` from the raw payload, so a
+// non-string value (a plain object, which `toBufferLike` serializes to a JSON
+// string) was broadcast as a *binary* frame. The `_publish` fan-out path is only
+// hit by subscribers other than the first (the first receives via `peer.send`,
+// which was already correct), so the test needs two subscribers and asserts the
+// second one receives a text frame.
+describe("node (publish object frame type)", () => {
+  let server: Server;
+  let url: string;
+  let ws: ReturnType<typeof nodeAdapter>;
+
+  beforeAll(async () => {
+    ws = nodeAdapter({
+      hooks: defineHooks({
+        open(peer) {
+          peer.subscribe("room");
+        },
+      }),
+    });
+    server = createServer((_req, res) => res.end("ok"));
+    server.on("upgrade", ws.handleUpgrade);
+    const port = await getRandomPort("localhost");
+    url = `ws://localhost:${port}/`;
+    await new Promise<void>((resolve) => server.listen(port, resolve));
+    await waitForPort(port);
+  });
+
+  afterAll(async () => {
+    await ws.close();
+    server.close();
+  });
+
+  test("publishing a plain object delivers a text frame, not binary", async () => {
+    const clientA = await wsConnect(url); // first subscriber -> receives via send()
+    const clientB = await wsConnect(url); // later subscriber -> receives via _publish()
+    // Let both open hooks subscribe to "room" before publishing.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    // Inspect the raw frame on B: a text frame arrives as a string, a binary
+    // frame as an ArrayBuffer (wsConnect sets binaryType = "arraybuffer").
+    const frame = new Promise<{ isString: boolean; data: unknown }>((resolve) => {
+      clientB.ws.addEventListener("message", (event) => {
+        resolve({ isString: typeof event.data === "string", data: event.data });
+      });
+    });
+    void clientA;
+
+    ws.publish("room", { hello: "world" });
+
+    const received = await frame;
+    expect(received.isString).toBe(true);
+    expect(JSON.parse(received.data as string)).toEqual({ hello: "world" });
   });
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed frame type handling when publishing plain objects—now correctly sent as text frames instead of binary frames.

* **Tests**
  * Added regression test suite verifying proper frame type behavior when publishing plain objects through internal routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->