### PR TITLE
feat(peer): backpressure support

### DIFF
--- a/docs/1.guide/2.hooks.md
+++ b/docs/1.guide/2.hooks.md
@@ -41,6 +41,12 @@ const hooks = defineHooks({
   error(peer, error) {
     console.log("[ws] error", peer, error);
   },
+
+  drain(peer) {
+    // Send buffer drained after backpressure — safe to resume sending.
+    // Pair with `peer.bufferedAmount`. Not all adapters emit this.
+    console.log("[ws] drain", peer);
+  },
 });
 ```
 

--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -89,7 +89,10 @@ for (const chunk of stream) {
 }
 ```
 
-It resolves immediately when there is no backpressure (or on adapters that do not report `bufferedAmount`). On adapters with a `drain` signal it resolves as soon as the buffer drains; otherwise it polls every `pollInterval` ms (default `100`). Pass a `signal` (e.g. `AbortSignal.timeout(ms)`) to abort the wait — the promise then rejects with the signal's reason.
+It resolves immediately when there is no backpressure (or on adapters that do not report `bufferedAmount`). Otherwise it polls every `pollInterval` ms (default `100`) until the buffer drains, and also resolves early if the connection is no longer open so a send loop never hangs on a dropped client. Pass a `signal` (e.g. `AbortSignal.timeout(ms)`) to abort the wait — the promise then rejects with the signal's reason.
+
+> [!TIP]
+> For event-driven backpressure (instead of `await`ing in a loop), use the [`drain` hook](/guide/hooks) together with `peer.bufferedAmount`.
 
 ### `peer.subscribe(channel)`
 

--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -64,24 +64,7 @@ Peer's pubsub namespace.
 
 Number of bytes queued for transmission but not yet flushed to the client.
 
-Use this to apply **backpressure**: pause sending while it grows past a high watermark and resume once it drops (or when the [`drain`](/guide/hooks#drain) hook fires). This prevents a fast producer (for example a streaming async generator) from filling the adapter's send buffer faster than the client can drain it.
-
-```ts
-// Throttle a fast producer to the client's pace
-for (const chunk of stream) {
-  peer.send(chunk);
-  if (peer.bufferedAmount > 1024 * 1024 /* 1MB */) {
-    await new Promise((resolve) => {
-      const timer = setInterval(() => {
-        if (peer.bufferedAmount < 256 * 1024 /* 256KB */) {
-          clearInterval(timer);
-          resolve();
-        }
-      }, 10);
-    });
-  }
-}
-```
+Use this to apply **backpressure**: pause sending while it grows past a high watermark and resume once it drops. This prevents a fast producer (for example a streaming async generator) from filling the adapter's send buffer faster than the client can drain it. The easiest way to wait is [`peer.waitForDrain()`](#peerwaitfordrain).
 
 > [!NOTE]
 > Not all adapters expose a buffer signal; those return `0`. Refer to the [compatibility table](#compatibility) for more info.
@@ -91,6 +74,22 @@ for (const chunk of stream) {
 ### `peer.send(message, { compress? })`
 
 Send a message to the connected client.
+
+### `peer.waitForDrain({ threshold?, pollInterval?, signal? })`
+
+Returns a promise that resolves once [`peer.bufferedAmount`](#peerbufferedamount) drops to or below `threshold` bytes (default `0`), letting you `await` backpressure relief in a send loop:
+
+```ts
+// Throttle a fast producer to the client's pace
+for (const chunk of stream) {
+  peer.send(chunk);
+  if (peer.bufferedAmount > 1024 * 1024 /* 1MB */) {
+    await peer.waitForDrain({ threshold: 256 * 1024 /* 256KB */ });
+  }
+}
+```
+
+It resolves immediately when there is no backpressure (or on adapters that do not report `bufferedAmount`). On adapters with a `drain` signal it resolves as soon as the buffer drains; otherwise it polls every `pollInterval` ms (default `100`). Pass a `signal` (e.g. `AbortSignal.timeout(ms)`) to abort the wait — the promise then rejects with the signal's reason.
 
 ### `peer.subscribe(channel)`
 

--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -60,6 +60,32 @@ All topics, this peer has been subscribed to.
 
 Peer's pubsub namespace.
 
+### `peer.bufferedAmount`
+
+Number of bytes queued for transmission but not yet flushed to the client.
+
+Use this to apply **backpressure**: pause sending while it grows past a high watermark and resume once it drops (or when the [`drain`](/guide/hooks#drain) hook fires). This prevents a fast producer (for example a streaming async generator) from filling the adapter's send buffer faster than the client can drain it.
+
+```ts
+// Throttle a fast producer to the client's pace
+for (const chunk of stream) {
+  peer.send(chunk);
+  if (peer.bufferedAmount > 1024 * 1024 /* 1MB */) {
+    await new Promise((resolve) => {
+      const timer = setInterval(() => {
+        if (peer.bufferedAmount < 256 * 1024 /* 256KB */) {
+          clearInterval(timer);
+          resolve();
+        }
+      }, 10);
+    });
+  }
+}
+```
+
+> [!NOTE]
+> Not all adapters expose a buffer signal; those return `0`. Refer to the [compatibility table](#compatibility) for more info.
+
 ## Instance methods
 
 ### `peer.send(message, { compress? })`
@@ -113,6 +139,8 @@ To gracefully close the connection, use `peer.close()`.
 | `publish()` / `subscribe()` | ✓          | ⨉                 | ✓ [^1]                      | ✓ [^1]       | ✓ [^1]              | ✓                             | ✓ [^1]     |
 | `close()`                   | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
 | `terminate()`               | ✓          | ✓ [^2]            | ✓                           | ✓            | ✓                   | ✓                             | ✓ [^2]     |
+| `bufferedAmount`            | ✓          | ⨉ [^8]            | ⨉ [^8]                      | ✓            | ✓                   | ✓                             | ⨉ [^8]     |
+| `drain` hook                | ✓          | ⨉ [^9]            | ⨉ [^9]                      | ⨉ [^9]       | ✓                   | ✓                             | ⨉ [^9]     |
 | `request`                   | ✓          | ✓                 | ✓ [^30]                     | ✓            | ✓ [^31]             | ✓ [^31]                       | ✓          |
 | `remoteAddress`             | ✓          | ⨉                 | ⨉                           | ✓            | ✓                   | ✓                             | ⨉          |
 | `websocket.url`             | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
@@ -145,3 +173,7 @@ To gracefully close the connection, use `peer.close()`.
 [^6]: [`websocket.readyState`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/readyState) is polyfilled by tracking open/close events.
 
 [^7]: Some runtimes have non standard values including `"nodebuffer"` and `"uint8array"`. crossws auto converts them for [`message.data`](/guide/message#messagedata).
+
+[^8]: The runtime exposes no send-buffer signal, so `peer.bufferedAmount` reports `0`. (Cloudflare buffers and applies backpressure internally; SSE has no equivalent.)
+
+[^9]: The runtime emits no drain signal. Poll [`peer.bufferedAmount`](#peerbufferedamount) instead where it is available.

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -76,7 +76,6 @@ const bunAdapter: Adapter<BunAdapter, BunOptions> = (options = {}) => {
       drain: (ws) => {
         const peers = getPeers(globalPeers, ws.data.namespace);
         const peer = getPeer(ws, peers);
-        peer._emitDrain();
         hooks.callHook("drain", peer);
       },
     },

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -76,6 +76,7 @@ const bunAdapter: Adapter<BunAdapter, BunOptions> = (options = {}) => {
       drain: (ws) => {
         const peers = getPeers(globalPeers, ws.data.namespace);
         const peer = getPeer(ws, peers);
+        peer._emitDrain();
         hooks.callHook("drain", peer);
       },
     },

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -73,6 +73,11 @@ const bunAdapter: Adapter<BunAdapter, BunOptions> = (options = {}) => {
         peers.delete(peer);
         hooks.callHook("close", peer, { code, reason });
       },
+      drain: (ws) => {
+        const peers = getPeers(globalPeers, ws.data.namespace);
+        const peer = getPeer(ws, peers);
+        hooks.callHook("drain", peer);
+      },
     },
   };
 };
@@ -107,6 +112,10 @@ class BunPeer extends Peer<{
 
   override get context(): PeerContext {
     return this._internal.ws.data.context;
+  }
+
+  override get bufferedAmount(): number {
+    return this._internal.ws.getBufferedAmount();
   }
 
   send(data: unknown, options?: { compress?: boolean }): number {

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -81,20 +81,21 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
       peers.delete(peer);
       hooks.callHook("error", peer, new WSError(error));
     });
+    // `ws` has no drain event of its own; the underlying TCP socket emits
+    // `drain` after a backpressured write flushes. Note this tracks the OS
+    // socket buffer, which is an approximation of `peer.bufferedAmount` (the
+    // latter also includes ws's internal sender queue) — treat it as a resume
+    // nudge, not an exact "bufferedAmount reached 0" signal.
+    const socket = (ws as WebSocketT & { _socket?: Duplex })._socket;
+    const onDrain = () => hooks.callHook("drain", peer);
+    socket?.on("drain", onDrain);
     ws.on("close", (code: number, reason: Buffer) => {
       peers.delete(peer);
+      socket?.off("drain", onDrain);
       hooks.callHook("close", peer, {
         code,
         reason: reason?.toString(),
       });
-    });
-    // `ws` has no drain event of its own; the underlying TCP socket emits
-    // `drain` only after a write was backpressured, which is exactly the
-    // signal we want for `peer.bufferedAmount`-based throttling.
-    const socket = (ws as WebSocketT & { _socket?: Duplex })._socket;
-    socket?.on("drain", () => {
-      peer._emitDrain();
-      hooks.callHook("drain", peer);
     });
   });
 

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -88,6 +88,13 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
         reason: reason?.toString(),
       });
     });
+    // `ws` has no drain event of its own; the underlying TCP socket emits
+    // `drain` only after a write was backpressured, which is exactly the
+    // signal we want for `peer.bufferedAmount`-based throttling.
+    const socket = (ws as WebSocketT & { _socket?: Duplex })._socket;
+    socket?.on("drain", () => {
+      hooks.callHook("drain", peer);
+    });
   });
 
   wss.on("headers", (outgoingHeaders, req) => {
@@ -166,7 +173,7 @@ class NodePeer extends Peer<{
       binary: isBinary,
       ...options,
     });
-    return 0;
+    return this._internal.ws.bufferedAmount;
   }
 
   publish(topic: string, data: unknown, options?: { compress?: boolean }): void {

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -93,6 +93,7 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
     // signal we want for `peer.bufferedAmount`-based throttling.
     const socket = (ws as WebSocketT & { _socket?: Duplex })._socket;
     socket?.on("drain", () => {
+      peer._emitDrain();
       hooks.callHook("drain", peer);
     });
   });

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -64,7 +64,6 @@ const uwsAdapter: Adapter<UWSAdapter, UWSOptions> = (options = {}) => {
       drain(ws) {
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
         const peer = getPeer(ws, peers);
-        peer._emitDrain();
         hooks.callHook("drain", peer);
       },
       open(ws) {

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -61,6 +61,11 @@ const uwsAdapter: Adapter<UWSAdapter, UWSOptions> = (options = {}) => {
         const peer = getPeer(ws, peers);
         hooks.callHook("message", peer, new Message(message, peer));
       },
+      drain(ws) {
+        const peers = getPeers(globalPeers, ws.getUserData().namespace);
+        const peer = getPeer(ws, peers);
+        hooks.callHook("drain", peer);
+      },
       open(ws) {
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
         const peer = getPeer(ws, peers);

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -64,6 +64,7 @@ const uwsAdapter: Adapter<UWSAdapter, UWSOptions> = (options = {}) => {
       drain(ws) {
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
         const peer = getPeer(ws, peers);
+        peer._emitDrain();
         hooks.callHook("drain", peer);
       },
       open(ws) {

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -146,6 +146,15 @@ export interface Hooks {
   /** A socket is closed */
   close: (peer: Peer, details: { code?: number; reason?: string }) => MaybePromise<void>;
 
+  /**
+   * The send buffer has drained after backpressure, so it is safe to resume
+   * sending. Pair with {@link Peer.bufferedAmount} to throttle senders.
+   *
+   * **Note:** Only emitted by adapters that expose a drain signal. Refer to the
+   * [compatibility table](https://crossws.h3.dev/guide/peer#compatibility).
+   */
+  drain: (peer: Peer) => MaybePromise<void>;
+
   /** An error occurs */
   error: (peer: Peer, error: WSError) => MaybePromise<void>;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ export type { Adapter, AdapterInstance, AdapterOptions } from "./adapter.ts";
 export type { Message } from "./message.ts";
 
 // Peer
-export type { Peer, PeerContext, AdapterInternal } from "./peer.ts";
+export type { Peer, PeerContext, AdapterInternal, WaitForDrainOptions } from "./peer.ts";
 
 // Error
 export type { WSError } from "./error.ts";

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -3,6 +3,29 @@ import { kNodeInspect } from "./utils.ts";
 
 export interface PeerContext extends Record<string, unknown> {}
 
+export interface WaitForDrainOptions {
+  /**
+   * Resolve once {@link Peer.bufferedAmount} drops to or below this many bytes.
+   *
+   * @default 0
+   */
+  threshold?: number;
+
+  /**
+   * Polling interval (in milliseconds) used as a fallback on adapters without a
+   * native `drain` signal. Capable adapters resolve on the drain event instead.
+   *
+   * @default 100
+   */
+  pollInterval?: number;
+
+  /**
+   * Abort the wait (e.g. `AbortSignal.timeout(ms)`). The returned promise
+   * rejects with the signal's `reason`.
+   */
+  signal?: AbortSignal;
+}
+
 export interface AdapterInternal {
   ws: unknown;
   request: Request;
@@ -17,6 +40,7 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   protected _id?: string;
 
   #ws?: Partial<web.WebSocket>;
+  #drainWaiters?: Set<() => void>;
 
   constructor(internal: Internal) {
     this._topics = new Set();
@@ -88,6 +112,70 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
    */
   get bufferedAmount(): number {
     return (this._internal.ws as Partial<web.WebSocket>)?.bufferedAmount ?? 0;
+  }
+
+  /**
+   * Wait until the send buffer drains to `threshold` bytes (default `0`).
+   *
+   * Resolves immediately when there is no backpressure (or on adapters that do
+   * not expose {@link Peer.bufferedAmount}). On adapters with a `drain` signal
+   * it resolves as soon as the buffer drains; otherwise it polls every
+   * `pollInterval` milliseconds.
+   *
+   * ```ts
+   * for (const chunk of stream) {
+   *   peer.send(chunk);
+   *   if (peer.bufferedAmount > 1024 * 1024) {
+   *     await peer.waitForDrain({ threshold: 256 * 1024 });
+   *   }
+   * }
+   * ```
+   */
+  waitForDrain(opts: WaitForDrainOptions = {}): Promise<void> {
+    const threshold = opts.threshold ?? 0;
+    if (this.bufferedAmount <= threshold) {
+      return Promise.resolve();
+    }
+    const signal = opts.signal;
+    if (signal?.aborted) {
+      return Promise.reject(signal.reason);
+    }
+    const waiters = (this.#drainWaiters ??= new Set<() => void>());
+    return new Promise<void>((resolve, reject) => {
+      const check = () => {
+        if (this.bufferedAmount <= threshold) {
+          cleanup();
+          resolve();
+        }
+      };
+      const onAbort = () => {
+        cleanup();
+        reject(signal!.reason);
+      };
+      const timer = setInterval(check, opts.pollInterval ?? 100);
+      const cleanup = () => {
+        clearInterval(timer);
+        waiters.delete(check);
+        signal?.removeEventListener("abort", onAbort);
+      };
+      waiters.add(check);
+      signal?.addEventListener("abort", onAbort, { once: true });
+    });
+  }
+
+  /**
+   * Notify pending {@link Peer.waitForDrain} callers that the send buffer has
+   * drained. Called by adapters that expose a native `drain` signal.
+   *
+   * @internal
+   */
+  _emitDrain(): void {
+    if (this.#drainWaiters?.size) {
+      // `check()` only removes its own entry, so iterating live is safe.
+      for (const check of this.#drainWaiters) {
+        check();
+      }
+    }
   }
 
   abstract close(code?: number, reason?: string): void;

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -12,8 +12,7 @@ export interface WaitForDrainOptions {
   threshold?: number;
 
   /**
-   * Polling interval (in milliseconds) used as a fallback on adapters without a
-   * native `drain` signal. Capable adapters resolve on the drain event instead.
+   * Polling interval (in milliseconds) used to re-check {@link Peer.bufferedAmount}.
    *
    * @default 100
    */
@@ -40,7 +39,6 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   protected _id?: string;
 
   #ws?: Partial<web.WebSocket>;
-  #drainWaiters?: Set<() => void>;
 
   constructor(internal: Internal) {
     this._topics = new Set();
@@ -118,9 +116,10 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
    * Wait until the send buffer drains to `threshold` bytes (default `0`).
    *
    * Resolves immediately when there is no backpressure (or on adapters that do
-   * not expose {@link Peer.bufferedAmount}). On adapters with a `drain` signal
-   * it resolves as soon as the buffer drains; otherwise it polls every
-   * `pollInterval` milliseconds.
+   * not expose {@link Peer.bufferedAmount}). Otherwise it polls every
+   * `pollInterval` milliseconds until the buffer drains, also resolving early if
+   * the connection is no longer open so a send loop never hangs on a dropped
+   * client.
    *
    * ```ts
    * for (const chunk of stream) {
@@ -140,10 +139,11 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
     if (signal?.aborted) {
       return Promise.reject(signal.reason);
     }
-    const waiters = (this.#drainWaiters ??= new Set<() => void>());
     return new Promise<void>((resolve, reject) => {
       const check = () => {
-        if (this.bufferedAmount <= threshold) {
+        // Resolve once drained, or if the socket left the OPEN (1) state — a
+        // closed peer never drains, so this prevents a permanent hang + leak.
+        if (this.bufferedAmount <= threshold || (this.websocket.readyState ?? 1) > 1) {
           cleanup();
           resolve();
         }
@@ -153,29 +153,14 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
         reject(signal!.reason);
       };
       const timer = setInterval(check, opts.pollInterval ?? 100);
+      // Don't keep the event loop alive just for a pending drain check.
+      timer.unref?.();
       const cleanup = () => {
         clearInterval(timer);
-        waiters.delete(check);
         signal?.removeEventListener("abort", onAbort);
       };
-      waiters.add(check);
       signal?.addEventListener("abort", onAbort, { once: true });
     });
-  }
-
-  /**
-   * Notify pending {@link Peer.waitForDrain} callers that the send buffer has
-   * drained. Called by adapters that expose a native `drain` signal.
-   *
-   * @internal
-   */
-  _emitDrain(): void {
-    if (this.#drainWaiters?.size) {
-      // `check()` only removes its own entry, so iterating live is safe.
-      for (const check of this.#drainWaiters) {
-        check();
-      }
-    }
   }
 
   abstract close(code?: number, reason?: string): void;

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -78,6 +78,18 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
     return this._topics;
   }
 
+  /**
+   * Number of bytes queued for transmission but not yet flushed to the client.
+   *
+   * Use this to apply backpressure: pause sending while it grows past a high
+   * watermark and resume once it drops (or on the `drain` hook). Returns `0` on
+   * adapters that do not expose a buffer signal. Refer to the
+   * [compatibility table](https://crossws.h3.dev/guide/peer#compatibility).
+   */
+  get bufferedAmount(): number {
+    return (this._internal.ws as Partial<web.WebSocket>)?.bufferedAmount ?? 0;
+  }
+
   abstract close(code?: number, reason?: string): void;
 
   /** Abruptly close the connection */

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -45,6 +45,10 @@ export function createDemo<T extends Adapter<any, any>>(
           });
           break;
         }
+        case "waitForDrain": {
+          peer.waitForDrain({ pollInterval: 10 }).then(() => peer.send("drained"));
+          break;
+        }
         case "peers": {
           peer.send({
             peers: [...peer.peers].map((p) => p.id),

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -28,6 +28,7 @@ export function createDemo<T extends Adapter<any, any>>(
           peer.send({
             id: peer.id,
             remoteAddress: peer.remoteAddress,
+            bufferedAmount: peer.bufferedAmount,
             context: peer.context,
             request: {
               url: peer.request?.url,

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -119,6 +119,15 @@ export function wsTests(getURL: () => string, opts: WSTestOpts): void {
     }
   });
 
+  test("peer.bufferedAmount", async () => {
+    const ws = await wsConnect(getURL(), { skip: 1 });
+    await ws.send("debug");
+    const { bufferedAmount } = await ws.next();
+    // Adapters without a buffer signal report 0; capable ones report >= 0.
+    expect(typeof bufferedAmount).toBe("number");
+    expect(bufferedAmount).toBeGreaterThanOrEqual(0);
+  });
+
   test("peer.websocket", async () => {
     const ws = await wsConnect(getURL() + "?foo=bar", {
       skip: 1,

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -128,6 +128,12 @@ export function wsTests(getURL: () => string, opts: WSTestOpts): void {
     expect(bufferedAmount).toBeGreaterThanOrEqual(0);
   });
 
+  test("peer.waitForDrain", async () => {
+    const ws = await wsConnect(getURL(), { skip: 1 });
+    await ws.send("waitForDrain");
+    expect(await ws.next()).toBe("drained");
+  });
+
   test("peer.websocket", async () => {
     const ws = await wsConnect(getURL() + "?foo=bar", {
       skip: 1,


### PR DESCRIPTION
Closes #194.

Right now `peer.send()` is fire-and-forget. If you produce messages faster than the client can receive them (a classic case: streaming an async generator), they pile up in the adapter's send buffer with no way to notice — and the process can eventually run out of memory.

This PR adds a small, native way to apply backpressure so a fast producer can slow down to match the client.

The simplest usage:

```ts
for (const chunk of stream) {
  peer.send(chunk);
  // pause when too much is buffered, resume once the client catches up
  if (peer.bufferedAmount > 1024 * 1024 /* 1MB */) {
    await peer.waitForDrain({ threshold: 256 * 1024 /* 256KB */ });
  }
}
```

What's new:

- **`peer.bufferedAmount`** — bytes queued but not yet flushed to the client. Read it to decide when to pause. Returns `0` on adapters that don't expose a buffer signal.
- **`peer.waitForDrain(opts?)`** — returns a promise that resolves once the buffer drains to `threshold` bytes (default `0`). Resolves immediately when there's no backpressure, otherwise polls every `pollInterval` ms (default `100`) until it drains. It also resolves early if the connection is no longer open, so a send loop never hangs on a dropped client. Pass an `AbortSignal` (e.g. `AbortSignal.timeout(ms)`) to cancel the wait.
- **`drain` hook** — fired when the send buffer empties after backpressure, if you'd rather handle it event-style instead of awaiting.

Adapter support:

- Full support (buffer signal + drain event): Node, Vercel, Bun, μWebSockets.
- Buffer signal only: Deno, Bunny.
- No signal (calls resolve immediately): Cloudflare (handles backpressure internally), SSE.