### PR TITLE
feat(proxy): support unix socket targets out of the box

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -28,6 +28,12 @@ export default defineBuildConfig({
           "@deno/types",
           "uWebSockets.js",
           "cloudflare:workers",
+          // Keep the self-referential `crossws/websocket` import as a bare
+          // specifier in the output so the consumer's runtime/bundler resolves
+          // it via the package `exports` conditions — letting a per-runtime
+          // bundle tree-shake the other runtimes' clients (e.g. `ws` out of
+          // a Deno or browser build).
+          "crossws/websocket",
         ],
       },
     },

--- a/build.config.ts
+++ b/build.config.ts
@@ -15,6 +15,8 @@ export default defineBuildConfig({
         "src/sync.ts",
         "src/websocket/native.ts",
         "src/websocket/node.ts",
+        "src/websocket/deno.ts",
+        "src/websocket/bun.ts",
         "src/websocket/sse.ts",
         ...adapters.map((id) => `src/adapters/${id}.ts`),
         ...servers.map((id) => `src/server/${id}.ts`),

--- a/docs/1.guide/8.proxy.md
+++ b/docs/1.guide/8.proxy.md
@@ -152,7 +152,7 @@ const hooks = createWebSocketProxy({
 
 ## Unix domain sockets
 
-Proxy to an upstream listening on a Unix domain socket by returning a `ws+unix://<socketPath>:<pathname>` target. This works **out of the box** on Node.js, Deno, and Bun — no custom `WebSocket` constructor required:
+Proxy to an upstream listening on a Unix domain socket by returning a `ws+unix://<socketPath>:<pathname>` target. This works **out of the box** on Node.js, Bun, and Deno — no custom `WebSocket` constructor required:
 
 ```ts
 import { createWebSocketProxy } from "crossws";
@@ -170,20 +170,20 @@ const hooks = createWebSocketProxy({
 });
 ```
 
-crossws picks the right dialing strategy for each runtime automatically:
+Under the hood the target is dialed through the [`crossws/websocket`](https://github.com/h3js/crossws/tree/main/src/websocket) client for the current runtime, which picks the right strategy automatically:
 
 - **Bun** — its global `WebSocket` dials `ws+unix:` natively.
-- **Deno** — its `WebSocket` rejects the scheme, so crossws keeps a plain `ws://` URL and routes the transport through Deno's unstable [`Deno.createHttpClient`](https://docs.deno.com/api/deno/~/Deno.createHttpClient) `client` option.
-- **Node.js** — its global (undici) `WebSocket` rejects the scheme, so crossws dials with the prebundled [`ws`](https://github.com/websockets/ws) client (loaded lazily, so it never enters the bundle on other runtimes).
+- **Node.js** — its global `WebSocket` rejects the scheme, so crossws dials with the [`ws`](https://github.com/websockets/ws) client instead (bundled with crossws, no extra dependency to install).
+- **Deno** — its global `WebSocket` rejects the scheme, so crossws routes the transport through [`Deno.createHttpClient`](https://docs.deno.com/api/deno/~/Deno.createHttpClient)'s unix `client`.
 
 Passing an explicit [`WebSocket` constructor](#custom-websocket-constructor) opts out of this per-runtime handling — the target is dialed with your constructor verbatim (e.g. `ws`, which accepts `ws+unix:` directly).
 
 > [!NOTE]
-> On Deno, dialing a Unix socket goes through `Deno.createHttpClient` with a unix transport, an **unstable** API — run Deno with the `--unstable-net` flag to enable it.
+> On **Deno**, the unix transport uses `Deno.createHttpClient`, an **unstable** API — run Deno with the `--unstable-net` flag to enable it.
 
 ## Per-peer constructor options
 
-For transports that can't be expressed in the target URL, `webSocketOptions` merges extra options — a static object or a per-peer resolver — into the upstream `WebSocket` constructor's third argument, alongside any [`headers`](#forwarding-headers). Use it for runtime- or client-specific dialing options the WHATWG signature doesn't cover (Unix sockets are handled automatically as [shown above](#unix-domain-sockets), so you rarely need this for them).
+For transports that can't be expressed in the target URL, `webSocketOptions` passes extra dialing options — a static object or a per-peer resolver — to the upstream `WebSocket` client, alongside any [`headers`](#forwarding-headers). Use it for runtime- or client-specific options the WHATWG signature doesn't cover — e.g. pinning the connection to a network interface, or supplying a custom transport client. ([Unix sockets](#unix-domain-sockets) are dialed automatically, so you don't need this for them.)
 
 For example, pinning the upstream connection to a specific network interface via [`ws`](https://github.com/websockets/ws)'s `createConnection`, or [`undici`](https://undici.nodejs.org)'s `dispatcher`:
 
@@ -201,8 +201,19 @@ const hooks = createWebSocketProxy({
 });
 ```
 
+On Deno, `webSocketOptions` also carries a custom [`Deno.createHttpClient`](https://docs.deno.com/api/deno/~/Deno.createHttpClient) `client` — for example to route the upstream through an HTTP proxy (a plain unix socket is handled automatically by a [`ws+unix:` target](#unix-domain-sockets)):
+
+```ts
+const hooks = createWebSocketProxy({
+  target: "wss://backend.internal/chat",
+  webSocketOptions: () => ({
+    client: Deno.createHttpClient({ proxy: { url: "http://proxy.internal:8080" } }),
+  }),
+});
+```
+
 > [!NOTE]
-> `webSocketOptions` is only honored by `WebSocket` constructors that accept a third options argument (the `ws`/`undici` clients, or the Deno/Bun runtime globals). The WHATWG browser global ignores it. Keys are merged with `headers`, with the dedicated `headers` option taking precedence over a `headers` key returned here.
+> `webSocketOptions` is only honored by `WebSocket` constructors that accept a dialing-options argument (the `ws`/`undici` clients, or Deno's global — crossws passes the options in the position each expects). The WHATWG browser global ignores them. Keys are merged with `headers`, with the dedicated `headers` option taking precedence over a `headers` key returned here.
 
 ## Forwarding headers
 
@@ -231,7 +242,7 @@ const hooks = createWebSocketProxy({
 
 Accepts either a target URL (`string` or `URL`), a resolver function, or an options object:
 
-- **`target`** — `string | URL | (peer: Peer) => string | URL | Promise<string | URL>`. The upstream WebSocket URL, or a function (optionally async) that resolves it per peer. Accepts `ws:`/`wss:`, and `ws+unix://<socketPath>:<pathname>` for a [Unix-socket upstream](#unix-domain-sockets) (dialed with the right per-runtime strategy on Node/Deno/Bun). The proxy does not otherwise enforce a scheme allowlist — any URL a custom `WebSocket` constructor accepts works. See the [SSRF warning](#dynamic-target) before using a dynamic resolver.
+- **`target`** — `string | URL | (peer: Peer) => string | URL | Promise<string | URL>`. The upstream WebSocket URL, or a function (optionally async) that resolves it per peer. Accepts `ws:`/`wss:`, and `ws+unix://<socketPath>:<pathname>` for a [Unix-socket upstream](#unix-domain-sockets) (dialed out of the box on Node, Bun, and Deno). The proxy does not otherwise enforce a scheme allowlist — any URL a custom `WebSocket` constructor accepts works. See the [SSRF warning](#dynamic-target) before using a dynamic resolver.
 - **`forwardProtocol`** — `boolean | string | string[] | Record<string, string> | (peer: Peer) => string | string[] | undefined` (default `true`). Controls the subprotocol(s) offered to the upstream:
   - `true` forwards the client's `sec-websocket-protocol` header verbatim; `false` offers none.
   - a `string`/`string[]` offers a fixed value upstream regardless of the client.
@@ -240,7 +251,7 @@ Accepts either a target URL (`string` or `URL`), a resolver function, or an opti
 
   See [rewriting the upstream subprotocol](#rewriting-the-upstream-subprotocol). In all cases the value echoed back to the client is the first client-offered token (RFC 6455), and values that are not valid RFC 7230 tokens are dropped from the echo.
 - **`headers`** — `HeadersInit | (peer: Peer) => HeadersInit`. Extra headers to send on the upstream handshake. Only honored when a custom `WebSocket` constructor that accepts a third options argument is supplied — the WHATWG global ignores it.
-- **`webSocketOptions`** — `Record<string, unknown> | (peer: Peer) => Record<string, unknown>`. Extra options merged into the upstream `WebSocket` constructor's third argument, statically or per peer. The escape hatch for transport options the URL can't express — e.g. the `ws`/`undici` `createConnection`/`dispatcher`/`agent`. Merged with `headers` (the `headers` option wins over a `headers` key returned here). See [per-peer constructor options](#per-peer-constructor-options). Only honored by constructors that accept a third argument. ([Unix sockets](#unix-domain-sockets) don't need this — they're dialed automatically per runtime.)
+- **`webSocketOptions`** — `Record<string, unknown> | (peer: Peer) => Record<string, unknown>`. Extra dialing options passed to the upstream `WebSocket` client, statically or per peer. The escape hatch for transport options the URL can't express — e.g. the `ws`/`undici` `createConnection`/`dispatcher`/`agent`, or a custom `Deno.createHttpClient` `client`. Merged with `headers` (the `headers` option wins over a `headers` key returned here). See [per-peer constructor options](#per-peer-constructor-options). Only honored by clients that accept dialing options (`ws`/`undici`, or Deno's global); the WHATWG browser global ignores them.
 - **`maxBufferSize`** — `number` (default `1048576`, i.e. 1 MiB). Maximum number of bytes buffered per peer while the upstream is still connecting. String frames are accounted at their UTF-8 worst case (3 bytes per UTF-16 code unit) to avoid undercounting multi-byte content. When exceeded, the peer is closed with code `1009` (Message Too Big). Set to `0` to disable.
 - **`connectTimeout`** — `number` (default `10000`). Milliseconds to wait for the upstream WebSocket handshake to complete — and, for an async `target` resolver, for the resolver to settle. If exceeded, the peer is closed with code `1011`. Set to `0` to disable.
 - **`WebSocket`** — `typeof WebSocket` (default `globalThis.WebSocket`). Custom `WebSocket` constructor used to dial the upstream. Falls back to the global when omitted; throws at setup time if neither is available.

--- a/docs/1.guide/8.proxy.md
+++ b/docs/1.guide/8.proxy.md
@@ -150,19 +150,59 @@ const hooks = createWebSocketProxy({
 });
 ```
 
-### Unix domain sockets
+## Unix domain sockets
 
-The proxy does not enforce any scheme allowlist — whatever the configured `WebSocket` constructor accepts is accepted. For example, the [`ws`](https://github.com/websockets/ws) package supports Unix domain sockets via its `ws+unix:` scheme:
+Proxy to an upstream listening on a Unix domain socket by returning a `ws+unix://<socketPath>:<pathname>` target. This works **out of the box** on Node.js, Deno, and Bun — no custom `WebSocket` constructor required:
 
 ```ts
-import { WebSocket } from "ws";
 import { createWebSocketProxy } from "crossws";
 
 const hooks = createWebSocketProxy({
-  target: "ws+unix:/var/run/backend.sock:/chat",
-  WebSocket: WebSocket as unknown as typeof globalThis.WebSocket,
+  target: "ws+unix:///var/run/backend.sock:/chat",
 });
 ```
+
+The path before the `:` is the socket file (`/var/run/backend.sock`); the path after it is the request path forwarded to the upstream (`/chat`). A dynamic resolver can build it per peer:
+
+```ts
+const hooks = createWebSocketProxy({
+  target: (peer) => `ws+unix:///run/backend.sock:${new URL(peer.request.url).pathname}`,
+});
+```
+
+crossws picks the right dialing strategy for each runtime automatically:
+
+- **Bun** — its global `WebSocket` dials `ws+unix:` natively.
+- **Deno** — its `WebSocket` rejects the scheme, so crossws keeps a plain `ws://` URL and routes the transport through Deno's unstable [`Deno.createHttpClient`](https://docs.deno.com/api/deno/~/Deno.createHttpClient) `client` option.
+- **Node.js** — its global (undici) `WebSocket` rejects the scheme, so crossws dials with the prebundled [`ws`](https://github.com/websockets/ws) client (loaded lazily, so it never enters the bundle on other runtimes).
+
+Passing an explicit [`WebSocket` constructor](#custom-websocket-constructor) opts out of this per-runtime handling — the target is dialed with your constructor verbatim (e.g. `ws`, which accepts `ws+unix:` directly).
+
+> [!NOTE]
+> On Deno, dialing a Unix socket goes through `Deno.createHttpClient` with a unix transport, an **unstable** API — run Deno with the `--unstable-net` flag to enable it.
+
+## Per-peer constructor options
+
+For transports that can't be expressed in the target URL, `webSocketOptions` merges extra options — a static object or a per-peer resolver — into the upstream `WebSocket` constructor's third argument, alongside any [`headers`](#forwarding-headers). Use it for runtime- or client-specific dialing options the WHATWG signature doesn't cover (Unix sockets are handled automatically as [shown above](#unix-domain-sockets), so you rarely need this for them).
+
+For example, pinning the upstream connection to a specific network interface via [`ws`](https://github.com/websockets/ws)'s `createConnection`, or [`undici`](https://undici.nodejs.org)'s `dispatcher`:
+
+```ts
+import { WebSocket } from "ws";
+import { connect } from "node:net";
+import { createWebSocketProxy } from "crossws";
+
+const hooks = createWebSocketProxy({
+  target: "ws://backend.internal/chat",
+  WebSocket: WebSocket as unknown as typeof globalThis.WebSocket,
+  webSocketOptions: () => ({
+    createConnection: () => connect({ host: "10.0.0.5", port: 80 }),
+  }),
+});
+```
+
+> [!NOTE]
+> `webSocketOptions` is only honored by `WebSocket` constructors that accept a third options argument (the `ws`/`undici` clients, or the Deno/Bun runtime globals). The WHATWG browser global ignores it. Keys are merged with `headers`, with the dedicated `headers` option taking precedence over a `headers` key returned here.
 
 ## Forwarding headers
 
@@ -191,7 +231,7 @@ const hooks = createWebSocketProxy({
 
 Accepts either a target URL (`string` or `URL`), a resolver function, or an options object:
 
-- **`target`** — `string | URL | (peer: Peer) => string | URL | Promise<string | URL>`. The upstream WebSocket URL, or a function (optionally async) that resolves it per peer. The proxy does not enforce a scheme allowlist; any URL the configured `WebSocket` constructor accepts (including `ws+unix:` with `ws`) works. See the [SSRF warning](#dynamic-target) before using a dynamic resolver.
+- **`target`** — `string | URL | (peer: Peer) => string | URL | Promise<string | URL>`. The upstream WebSocket URL, or a function (optionally async) that resolves it per peer. Accepts `ws:`/`wss:`, and `ws+unix://<socketPath>:<pathname>` for a [Unix-socket upstream](#unix-domain-sockets) (dialed with the right per-runtime strategy on Node/Deno/Bun). The proxy does not otherwise enforce a scheme allowlist — any URL a custom `WebSocket` constructor accepts works. See the [SSRF warning](#dynamic-target) before using a dynamic resolver.
 - **`forwardProtocol`** — `boolean | string | string[] | Record<string, string> | (peer: Peer) => string | string[] | undefined` (default `true`). Controls the subprotocol(s) offered to the upstream:
   - `true` forwards the client's `sec-websocket-protocol` header verbatim; `false` offers none.
   - a `string`/`string[]` offers a fixed value upstream regardless of the client.
@@ -200,6 +240,7 @@ Accepts either a target URL (`string` or `URL`), a resolver function, or an opti
 
   See [rewriting the upstream subprotocol](#rewriting-the-upstream-subprotocol). In all cases the value echoed back to the client is the first client-offered token (RFC 6455), and values that are not valid RFC 7230 tokens are dropped from the echo.
 - **`headers`** — `HeadersInit | (peer: Peer) => HeadersInit`. Extra headers to send on the upstream handshake. Only honored when a custom `WebSocket` constructor that accepts a third options argument is supplied — the WHATWG global ignores it.
+- **`webSocketOptions`** — `Record<string, unknown> | (peer: Peer) => Record<string, unknown>`. Extra options merged into the upstream `WebSocket` constructor's third argument, statically or per peer. The escape hatch for transport options the URL can't express — e.g. the `ws`/`undici` `createConnection`/`dispatcher`/`agent`. Merged with `headers` (the `headers` option wins over a `headers` key returned here). See [per-peer constructor options](#per-peer-constructor-options). Only honored by constructors that accept a third argument. ([Unix sockets](#unix-domain-sockets) don't need this — they're dialed automatically per runtime.)
 - **`maxBufferSize`** — `number` (default `1048576`, i.e. 1 MiB). Maximum number of bytes buffered per peer while the upstream is still connecting. String frames are accounted at their UTF-8 worst case (3 bytes per UTF-16 code unit) to avoid undercounting multi-byte content. When exceeded, the peer is closed with code `1009` (Message Too Big). Set to `0` to disable.
 - **`connectTimeout`** — `number` (default `10000`). Milliseconds to wait for the upstream WebSocket handshake to complete — and, for an async `target` resolver, for the resolver to settle. If exceeded, the peer is closed with code `1011`. Set to `0` to disable.
 - **`WebSocket`** — `typeof WebSocket` (default `globalThis.WebSocket`). Custom `WebSocket` constructor used to dial the upstream. Falls back to the global when omitted; throws at setup time if neither is available.

--- a/package.json
+++ b/package.json
@@ -43,8 +43,8 @@
     "./websocket": {
       "browser": "./dist/websocket/native.mjs",
       "worker": "./dist/websocket/native.mjs",
-      "bun": "./dist/websocket/native.mjs",
-      "deno": "./dist/websocket/native.mjs",
+      "bun": "./dist/websocket/bun.mjs",
+      "deno": "./dist/websocket/deno.mjs",
       "edge-light": "./dist/websocket/native.mjs",
       "workerd": "./dist/websocket/native.mjs",
       "node": "./dist/websocket/node.mjs",

--- a/package.json
+++ b/package.json
@@ -3,20 +3,10 @@
   "version": "0.4.7",
   "description": "Cross-platform WebSocket Servers for Node.js, Deno, Bun and Cloudflare Workers",
   "homepage": "https://crossws.h3.dev",
-  "license": "MIT",
   "repository": "h3js/crossws",
-  "files": [
-    "dist",
-    "adapters",
-    "websocket",
-    "server",
-    "*.d.ts"
-  ],
-  "type": "module",
+  "license": "MIT",
   "sideEffects": false,
-  "main": "./dist/index.mjs",
-  "module": "./dist/index.mjs",
-  "types": "./dist/index.d.mts",
+  "type": "module",
   "exports": {
     ".": "./dist/index.mjs",
     "./sync": "./dist/sync.mjs",
@@ -51,11 +41,22 @@
       "default": "./dist/websocket/native.mjs"
     }
   },
+  "main": "./dist/index.mjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.mts",
+  "files": [
+    "dist",
+    "adapters",
+    "websocket",
+    "server",
+    "*.d.ts"
+  ],
   "scripts": {
+    "prepare": "obuild --stub",
     "build": "obuild",
     "dev": "vitest",
-    "lint": "oxlint . && oxfmt --check src test",
     "fmt": "oxlint . --fix && oxfmt src test",
+    "lint": "oxlint . && oxfmt --check src test",
     "prepack": "pnpm run build",
     "play:bun": "bun --watch test/fixture/bun.ts",
     "play:cf": "wrangler dev --port 3001 -c test/fixture/wrangler.toml",
@@ -67,6 +68,9 @@
     "release": "pnpm test && pnpm build && changelogen --release && npm publish && git push --follow-tags",
     "test": "pnpm lint && pnpm typecheck && vitest run --coverage",
     "typecheck": "tsgo --noEmit --skipLibCheck"
+  },
+  "resolutions": {
+    "crossws": "workspace:*"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260629.1",
@@ -106,9 +110,6 @@
     "srvx": {
       "optional": true
     }
-  },
-  "resolutions": {
-    "crossws": "workspace:*"
   },
   "packageManager": "pnpm@11.7.0"
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -17,6 +17,11 @@ export interface WebSocketProxyOptions {
   /**
    * Target WebSocket URL to proxy to (`ws://` or `wss://`).
    *
+   * A `ws+unix://<socketPath>:<pathname>` target is also supported out of the
+   * box for proxying to a Unix-socket upstream, and is dialed with the right
+   * per-runtime strategy automatically on Node, Deno, and Bun (no custom
+   * {@link WebSocket} constructor required). See the guide for details.
+   *
    * Can be a static string/URL or a function that resolves the target dynamically
    * based on the incoming {@link Peer}. The resolver may be **async** (return a
    * promise) — useful when the upstream address isn't known yet at connect time
@@ -112,6 +117,42 @@ export interface WebSocketProxyOptions {
    * ```
    */
   headers?: HeadersInit | ((peer: Peer) => HeadersInit | undefined | void);
+
+  /**
+   * Extra options merged into the upstream `WebSocket` constructor's third
+   * argument, as a static object or a per-peer resolver.
+   *
+   * This is the escape hatch for runtime- or client-specific dialing options
+   * that the WHATWG `WebSocket` signature doesn't cover — e.g. Deno's unstable
+   * `client` (to dial a Unix socket or use a custom `Deno.HttpClient`), or the
+   * `ws`/`undici` `createConnection`/`dispatcher`/`agent` options.
+   *
+   * Merged with {@link headers}: keys returned here are spread first, then the
+   * resolved `headers` option is applied on top (so a dedicated `headers`
+   * option wins over a `headers` key returned here).
+   *
+   * > [!NOTE]
+   * > Only honored by `WebSocket` constructors that accept a third options
+   * > argument. The WHATWG global browser constructor ignores it; Deno and Bun
+   * > extend the signature with their own options.
+   *
+   * @example Proxy to a Unix socket on Deno
+   * ```ts
+   * createWebSocketProxy({
+   *   // Deno's WebSocket rejects the `ws+unix:` scheme, so keep a plain
+   *   // `ws://` target and redirect the transport via the `client` option.
+   *   target: (peer) => `ws://localhost${new URL(peer.request.url).pathname}`,
+   *   webSocketOptions: () => ({
+   *     client: Deno.createHttpClient({
+   *       proxy: { transport: "unix", path: "/run/worker.sock" },
+   *     }),
+   *   }),
+   * });
+   * ```
+   */
+  webSocketOptions?:
+    | Record<string, unknown>
+    | ((peer: Peer) => Record<string, unknown> | undefined | void);
 }
 
 /**
@@ -296,21 +337,84 @@ function _dialUpstream(
   // resolving — its state is gone from the map, so don't dial a stale upstream.
   if (upstreams.get(peer.id) !== state) return;
 
+  // Decide *how* to dial: for a plain `ws:`/`wss:` target this is the passed
+  // constructor and URL as-is; for a `ws+unix:` target it selects a per-runtime
+  // strategy, which on Node requires a lazy `import("ws")` and so is async.
+  let plan: _DialPlan | Promise<_DialPlan>;
+  try {
+    plan = _planDial(url, options, WebSocketCtor);
+  } catch {
+    // Unsupported unix runtime, or a synchronous strategy failure.
+    _cleanupState(upstreams, peer.id, state);
+    _safeClose(peer, 1011, "Upstream setup failed");
+    return;
+  }
+
+  if (plan instanceof Promise) {
+    plan.then(
+      (resolved) => _constructUpstream(upstreams, peer, state, resolved, options),
+      () => {
+        if (upstreams.get(peer.id) !== state) return;
+        _cleanupState(upstreams, peer.id, state);
+        _safeClose(peer, 1011, "Upstream setup failed");
+      },
+    );
+  } else {
+    _constructUpstream(upstreams, peer, state, plan, options);
+  }
+}
+
+// How to dial the upstream: which `WebSocket` constructor, the (possibly
+// rewritten) URL, and any runtime-specific constructor options to merge in
+// (e.g. Deno's unix `client`).
+interface _DialPlan {
+  ctor: typeof WebSocket;
+  url: URL;
+  options?: Record<string, unknown>;
+  // Deno's `WebSocket` takes its options (including `client` and `protocols`)
+  // as the *second* argument, not the WHATWG/`ws`/`undici` third. When set, the
+  // subprotocols and merged options are passed positionally as arg two.
+  optionsAsSecondArg?: boolean;
+}
+
+// Construct the upstream socket from a resolved dial plan and wire its
+// lifecycle back to the peer.
+function _constructUpstream(
+  upstreams: Map<string, UpstreamState>,
+  peer: Peer,
+  state: UpstreamState,
+  plan: _DialPlan,
+  options: WebSocketProxyOptions,
+): void {
+  // The peer may have closed while an async plan (e.g. Node's `import("ws")`)
+  // was resolving — don't attach a stale upstream.
+  if (upstreams.get(peer.id) !== state) return;
+
   let ws: WebSocket;
   try {
     const protocols = _resolveProtocols(peer, options.forwardProtocol);
-    const wsOptions = _resolveWsOptions(options.headers, peer);
-    // The WHATWG WebSocket constructor only takes (url, protocols);
-    // additional arguments are ignored. Custom clients like `ws` and
-    // `undici` accept a third options object where `headers` is
-    // honored — so always pass it when the user configured headers.
-    ws = wsOptions
-      ? new (WebSocketCtor as unknown as new (
-          url: URL,
-          protocols: string[] | undefined,
-          opts: { headers: HeadersInit },
-        ) => WebSocket)(url, protocols, wsOptions)
-      : new WebSocketCtor(url, protocols);
+    const wsOptions = _mergeWsOptions(plan.options, _resolveWsOptions(options, peer));
+    if (plan.optionsAsSecondArg) {
+      // Deno: `new WebSocket(url, { client, protocols, ... })`. Subprotocols
+      // travel inside the options object rather than as a positional argument.
+      const opts: Record<string, unknown> = { ...wsOptions };
+      if (protocols) opts.protocols = protocols;
+      ws = new (plan.ctor as unknown as new (url: URL, opts: Record<string, unknown>) => WebSocket)(
+        plan.url,
+        opts,
+      );
+    } else {
+      // WHATWG global takes only (url, protocols) and ignores extra args;
+      // `ws`/`undici` accept a third options object where `headers`,
+      // `webSocketOptions`, etc. are honored — so pass it when present.
+      ws = wsOptions
+        ? new (plan.ctor as unknown as new (
+            url: URL,
+            protocols: string[] | undefined,
+            opts: Record<string, unknown>,
+          ) => WebSocket)(plan.url, protocols, wsOptions)
+        : new plan.ctor(plan.url, protocols);
+    }
     ws.binaryType = "arraybuffer";
   } catch {
     // Bad target URL, disallowed scheme, invalid subprotocol token,
@@ -404,14 +508,113 @@ function _isThenable(value: unknown): value is PromiseLike<unknown> {
   );
 }
 
+// Build the upstream constructor's third argument by merging the per-peer
+// `webSocketOptions` escape hatch with the dedicated `headers` option. Returns
+// `undefined` when neither is configured so the WHATWG-only `(url, protocols)`
+// call path is preserved. The `headers` option is applied last so it wins over
+// any `headers` key returned by `webSocketOptions`.
 function _resolveWsOptions(
-  headers: WebSocketProxyOptions["headers"],
+  options: WebSocketProxyOptions,
   peer: Peer,
-): { headers: HeadersInit } | undefined {
-  if (!headers) return;
-  const resolved = typeof headers === "function" ? headers(peer) : headers;
-  if (!resolved) return;
-  return { headers: resolved };
+): Record<string, unknown> | undefined {
+  const { headers, webSocketOptions } = options;
+  const extra = typeof webSocketOptions === "function" ? webSocketOptions(peer) : webSocketOptions;
+  const resolvedHeaders = typeof headers === "function" ? headers(peer) : headers;
+  if (!extra && !resolvedHeaders) return;
+  const merged: Record<string, unknown> = { ...extra };
+  if (resolvedHeaders) merged.headers = resolvedHeaders;
+  return merged;
+}
+
+// Combine a runtime dial option (e.g. Deno's unix `client`) with the resolved
+// `headers`/`webSocketOptions`. User options are spread last so an explicit
+// `webSocketOptions` can override the runtime default. Returns `undefined` when
+// both are empty so the WHATWG-only `(url, protocols)` call path is preserved.
+function _mergeWsOptions(
+  runtime: Record<string, unknown> | undefined,
+  user: Record<string, unknown> | undefined,
+): Record<string, unknown> | undefined {
+  if (!runtime) return user;
+  return { ...runtime, ...user };
+}
+
+// Choose how to dial `url`. Plain `ws:`/`wss:` targets (and any target with an
+// explicit `WebSocket` constructor) dial as-is. A `ws+unix:` target selects a
+// per-runtime strategy so a Unix-socket upstream works out of the box:
+//
+// - Bun: its global `WebSocket` dials `ws+unix:` natively — pass through.
+// - Deno: its `WebSocket` rejects `ws+unix:`, so keep a plain `ws://` URL and
+//   route the transport through the unstable `client` option.
+// - Node: its global (undici) `WebSocket` rejects `ws+unix:`, so dial with the
+//   `ws` client, imported lazily so it never enters the eager load path of the
+//   runtime-agnostic `crossws` entry (which browsers/Workers also load).
+//
+// Returns a promise only for the Node path (the lazy import); other runtimes
+// resolve synchronously.
+function _planDial(
+  url: URL,
+  options: WebSocketProxyOptions,
+  WebSocketCtor: typeof WebSocket,
+): _DialPlan | Promise<_DialPlan> {
+  // A caller-supplied constructor is used verbatim — the user opted into
+  // whatever scheme handling it provides (e.g. `ws`'s `ws+unix:` support).
+  if (url.protocol !== "ws+unix:" || options.WebSocket) {
+    return { ctor: WebSocketCtor, url };
+  }
+
+  const runtime = globalThis as {
+    Bun?: unknown;
+    Deno?: { createHttpClient?: (opts: unknown) => unknown };
+    process?: { versions?: { node?: string } };
+  };
+
+  if (runtime.Bun) {
+    return { ctor: WebSocketCtor, url };
+  }
+
+  if (runtime.Deno?.createHttpClient) {
+    // Deno's WebSocket rejects `ws+unix:`, so keep a plain `ws://` URL and
+    // route the transport through the unstable unix HTTP client, passed as the
+    // second-argument options object (Deno's signature, verified at runtime).
+    const { socketPath, path } = _parseUnixTarget(url);
+    const client = runtime.Deno.createHttpClient({
+      proxy: { transport: "unix", path: socketPath },
+    });
+    return {
+      ctor: WebSocketCtor,
+      url: new URL(`ws://localhost${path}`),
+      options: { client },
+      optionsAsSecondArg: true,
+    };
+  }
+
+  if (runtime.process?.versions?.node) {
+    // Node's global (undici) `WebSocket` rejects `ws+unix:`, so dial with the
+    // `ws` client. `ws` is prebundled by obuild, so this dynamic import resolves
+    // to the shared chunk with no extra runtime dependency — and stays out of
+    // the edge/browser bundle's eager graph because it is imported lazily.
+    return import("ws").then((mod) => ({
+      ctor: ((mod as { WebSocket?: unknown }).WebSocket ??
+        (mod as { default?: unknown }).default) as typeof WebSocket,
+      url,
+    }));
+  }
+
+  throw new Error(`crossws proxy cannot dial a \`ws+unix:\` target on this runtime.`);
+}
+
+// Split a `ws+unix://<socketPath>:<pathname>` URL into its socket path and the
+// upstream request path, mirroring how the `ws` client parses the scheme. The
+// socket path is everything before the first `:` in the URL path; the rest
+// (plus any query string) is the request path, defaulting to `/`.
+/** @internal exported for tests */
+export function _parseUnixTarget(url: URL): { socketPath: string; path: string } {
+  const raw = url.pathname + url.search;
+  const colon = raw.indexOf(":");
+  if (colon === -1) {
+    return { socketPath: raw, path: "/" };
+  }
+  return { socketPath: raw.slice(0, colon), path: raw.slice(colon + 1) || "/" };
 }
 
 /** @internal exported for tests */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -18,9 +18,9 @@ export interface WebSocketProxyOptions {
    * Target WebSocket URL to proxy to (`ws://` or `wss://`).
    *
    * A `ws+unix://<socketPath>:<pathname>` target is also supported out of the
-   * box for proxying to a Unix-socket upstream, and is dialed with the right
-   * per-runtime strategy automatically on Node, Deno, and Bun (no custom
-   * {@link WebSocket} constructor required). See the guide for details.
+   * box for proxying to a Unix-socket upstream on Node, Bun, and Deno (no custom
+   * {@link WebSocket} constructor required) — crossws dials it through the
+   * matching per-runtime `crossws/websocket` client. See the guide for details.
    *
    * Can be a static string/URL or a function that resolves the target dynamically
    * based on the incoming {@link Peer}. The resolver may be **async** (return a
@@ -364,16 +364,13 @@ function _dialUpstream(
   }
 }
 
-// How to dial the upstream: which `WebSocket` constructor, the (possibly
-// rewritten) URL, and any runtime-specific constructor options to merge in
-// (e.g. Deno's unix `client`).
+// How to dial the upstream: which `WebSocket` constructor and URL to dial.
 interface _DialPlan {
   ctor: typeof WebSocket;
   url: URL;
-  options?: Record<string, unknown>;
-  // Deno's `WebSocket` takes its options (including `client` and `protocols`)
-  // as the *second* argument, not the WHATWG/`ws`/`undici` third. When set, the
-  // subprotocols and merged options are passed positionally as arg two.
+  // Deno's global `WebSocket` takes its options (including `client` and
+  // `protocols`) as the *second* argument, not the WHATWG/`ws`/`undici` third.
+  // When set, the subprotocols and resolved options are passed as arg two.
   optionsAsSecondArg?: boolean;
 }
 
@@ -393,8 +390,12 @@ function _constructUpstream(
   let ws: WebSocket;
   try {
     const protocols = _resolveProtocols(peer, options.forwardProtocol);
-    const wsOptions = _mergeWsOptions(plan.options, _resolveWsOptions(options, peer));
-    if (plan.optionsAsSecondArg) {
+    const wsOptions = _resolveWsOptions(options, peer);
+    if (!wsOptions) {
+      // No extra options — the WHATWG-compatible `(url, protocols)` shape works
+      // on every runtime (including Deno's positional second argument).
+      ws = new plan.ctor(plan.url, protocols);
+    } else if (plan.optionsAsSecondArg) {
       // Deno: `new WebSocket(url, { client, protocols, ... })`. Subprotocols
       // travel inside the options object rather than as a positional argument.
       const opts: Record<string, unknown> = { ...wsOptions };
@@ -404,16 +405,14 @@ function _constructUpstream(
         opts,
       );
     } else {
-      // WHATWG global takes only (url, protocols) and ignores extra args;
       // `ws`/`undici` accept a third options object where `headers`,
-      // `webSocketOptions`, etc. are honored — so pass it when present.
-      ws = wsOptions
-        ? new (plan.ctor as unknown as new (
-            url: URL,
-            protocols: string[] | undefined,
-            opts: Record<string, unknown>,
-          ) => WebSocket)(plan.url, protocols, wsOptions)
-        : new plan.ctor(plan.url, protocols);
+      // `webSocketOptions`, etc. are honored. The WHATWG browser global ignores
+      // the extra argument, which is documented for those options.
+      ws = new (plan.ctor as unknown as new (
+        url: URL,
+        protocols: string[] | undefined,
+        opts: Record<string, unknown>,
+      ) => WebSocket)(plan.url, protocols, wsOptions);
     }
     ws.binaryType = "arraybuffer";
   } catch {
@@ -526,95 +525,58 @@ function _resolveWsOptions(
   return merged;
 }
 
-// Combine a runtime dial option (e.g. Deno's unix `client`) with the resolved
-// `headers`/`webSocketOptions`. User options are spread last so an explicit
-// `webSocketOptions` can override the runtime default. Returns `undefined` when
-// both are empty so the WHATWG-only `(url, protocols)` call path is preserved.
-function _mergeWsOptions(
-  runtime: Record<string, unknown> | undefined,
-  user: Record<string, unknown> | undefined,
-): Record<string, unknown> | undefined {
-  if (!runtime) return user;
-  return { ...runtime, ...user };
-}
-
 // Choose how to dial `url`. Plain `ws:`/`wss:` targets (and any target with an
-// explicit `WebSocket` constructor) dial as-is. A `ws+unix:` target selects a
-// per-runtime strategy so a Unix-socket upstream works out of the box:
+// explicit `WebSocket` constructor) dial as-is. A `ws+unix:` target is delegated
+// to the matching per-runtime `crossws/websocket` client, which knows how to
+// reach a Unix socket on its runtime, so it works out of the box:
 //
 // - Bun: its global `WebSocket` dials `ws+unix:` natively — pass through.
-// - Deno: its `WebSocket` rejects `ws+unix:`, so keep a plain `ws://` URL and
-//   route the transport through the unstable `client` option.
-// - Node: its global (undici) `WebSocket` rejects `ws+unix:`, so dial with the
-//   `ws` client, imported lazily so it never enters the eager load path of the
-//   runtime-agnostic `crossws` entry (which browsers/Workers also load).
+// - Node: the `crossws/websocket` Node client routes `ws+unix:` through `ws`.
+// - Deno: the `crossws/websocket` Deno client routes it through a unix
+//   `Deno.createHttpClient` transport.
 //
-// Returns a promise only for the Node path (the lazy import); other runtimes
-// resolve synchronously.
+// The wrappers are imported lazily so their `ws`/Deno-specific code never enters
+// the eager graph of the runtime-agnostic `crossws` entry (which browsers and
+// Workers also load). Returns a promise only for those lazy imports; the plain
+// and Bun paths resolve synchronously.
 function _planDial(
   url: URL,
   options: WebSocketProxyOptions,
   WebSocketCtor: typeof WebSocket,
 ): _DialPlan | Promise<_DialPlan> {
+  const runtime = globalThis as {
+    Bun?: unknown;
+    Deno?: unknown;
+    process?: { versions?: { node?: string } };
+  };
+
+  // Deno's global `WebSocket` takes options as its second argument, unlike the
+  // WHATWG/`ws`/`undici` third — flag it so `webSocketOptions` (e.g. a unix
+  // `client`) reaches Deno. A custom `WebSocket` is assumed to follow the
+  // WHATWG/`ws` third-argument shape.
+  const optionsAsSecondArg = !options.WebSocket && !!runtime.Deno;
+
   // A caller-supplied constructor is used verbatim — the user opted into
   // whatever scheme handling it provides (e.g. `ws`'s `ws+unix:` support).
   if (url.protocol !== "ws+unix:" || options.WebSocket) {
-    return { ctor: WebSocketCtor, url };
+    return { ctor: WebSocketCtor, url, optionsAsSecondArg };
   }
-
-  const runtime = globalThis as {
-    Bun?: unknown;
-    Deno?: { createHttpClient?: (opts: unknown) => unknown };
-    process?: { versions?: { node?: string } };
-  };
 
   if (runtime.Bun) {
     return { ctor: WebSocketCtor, url };
   }
 
-  if (runtime.Deno?.createHttpClient) {
-    // Deno's WebSocket rejects `ws+unix:`, so keep a plain `ws://` URL and
-    // route the transport through the unstable unix HTTP client, passed as the
-    // second-argument options object (Deno's signature, verified at runtime).
-    const { socketPath, path } = _parseUnixTarget(url);
-    const client = runtime.Deno.createHttpClient({
-      proxy: { transport: "unix", path: socketPath },
-    });
-    return {
-      ctor: WebSocketCtor,
-      url: new URL(`ws://localhost${path}`),
-      options: { client },
-      optionsAsSecondArg: true,
-    };
+  if (runtime.Deno) {
+    return import("./websocket/deno.ts").then((mod) => ({ ctor: mod.default, url }));
   }
 
   if (runtime.process?.versions?.node) {
-    // Node's global (undici) `WebSocket` rejects `ws+unix:`, so dial with the
-    // `ws` client. `ws` is prebundled by obuild, so this dynamic import resolves
-    // to the shared chunk with no extra runtime dependency — and stays out of
-    // the edge/browser bundle's eager graph because it is imported lazily.
-    return import("ws").then((mod) => ({
-      ctor: ((mod as { WebSocket?: unknown }).WebSocket ??
-        (mod as { default?: unknown }).default) as typeof WebSocket,
-      url,
-    }));
+    return import("./websocket/node.ts").then((mod) => ({ ctor: mod.default, url }));
   }
 
-  throw new Error(`crossws proxy cannot dial a \`ws+unix:\` target on this runtime.`);
-}
-
-// Split a `ws+unix://<socketPath>:<pathname>` URL into its socket path and the
-// upstream request path, mirroring how the `ws` client parses the scheme. The
-// socket path is everything before the first `:` in the URL path; the rest
-// (plus any query string) is the request path, defaulting to `/`.
-/** @internal exported for tests */
-export function _parseUnixTarget(url: URL): { socketPath: string; path: string } {
-  const raw = url.pathname + url.search;
-  const colon = raw.indexOf(":");
-  if (colon === -1) {
-    return { socketPath: raw, path: "/" };
-  }
-  return { socketPath: raw.slice(0, colon), path: raw.slice(colon + 1) || "/" };
+  throw new Error(
+    `crossws proxy cannot dial a \`ws+unix:\` target on this runtime — pass a \`WebSocket\` option that supports the scheme.`,
+  );
 }
 
 /** @internal exported for tests */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,11 @@
 import type { Hooks } from "./hooks.ts";
 import type { Peer } from "./peer.ts";
+// Per-runtime WebSocket client, resolved statically via the `crossws/websocket`
+// export conditions (node → `ws`, deno → unix `client`, bun/native → global).
+// Because it's a static conditional import, a bundle built for a specific
+// runtime tree-shakes the other runtimes' code (e.g. `ws`/`node:*` never enter
+// a Deno or browser bundle).
+import runtimeWebSocket from "crossws/websocket";
 
 // 1 MiB — generous enough for typical chatty clients while bounding memory
 // consumption of stalled-upstream peers.
@@ -174,7 +180,7 @@ export function createWebSocketProxy(
       ? { target }
       : target;
 
-  const WebSocketCtor = options.WebSocket ?? globalThis.WebSocket;
+  const WebSocketCtor = options.WebSocket ?? runtimeWebSocket;
   if (typeof WebSocketCtor !== "function") {
     throw new TypeError(
       "createWebSocketProxy requires a `WebSocket` constructor. Pass one via the `WebSocket` option, or use a runtime that provides a global `WebSocket` (Node.js >= 22, Bun, Deno, Cloudflare Workers, browsers).",
@@ -337,83 +343,22 @@ function _dialUpstream(
   // resolving — its state is gone from the map, so don't dial a stale upstream.
   if (upstreams.get(peer.id) !== state) return;
 
-  // Decide *how* to dial: for a plain `ws:`/`wss:` target this is the passed
-  // constructor and URL as-is; for a `ws+unix:` target it selects a per-runtime
-  // strategy, which on Node requires a lazy `import("ws")` and so is async.
-  let plan: _DialPlan | Promise<_DialPlan>;
-  try {
-    plan = _planDial(url, options, WebSocketCtor);
-  } catch {
-    // Unsupported unix runtime, or a synchronous strategy failure.
-    _cleanupState(upstreams, peer.id, state);
-    _safeClose(peer, 1011, "Upstream setup failed");
-    return;
-  }
-
-  if (plan instanceof Promise) {
-    plan.then(
-      (resolved) => _constructUpstream(upstreams, peer, state, resolved, options),
-      () => {
-        if (upstreams.get(peer.id) !== state) return;
-        _cleanupState(upstreams, peer.id, state);
-        _safeClose(peer, 1011, "Upstream setup failed");
-      },
-    );
-  } else {
-    _constructUpstream(upstreams, peer, state, plan, options);
-  }
-}
-
-// How to dial the upstream: which `WebSocket` constructor and URL to dial.
-interface _DialPlan {
-  ctor: typeof WebSocket;
-  url: URL;
-  // Deno's global `WebSocket` takes its options (including `client` and
-  // `protocols`) as the *second* argument, not the WHATWG/`ws`/`undici` third.
-  // When set, the subprotocols and resolved options are passed as arg two.
-  optionsAsSecondArg?: boolean;
-}
-
-// Construct the upstream socket from a resolved dial plan and wire its
-// lifecycle back to the peer.
-function _constructUpstream(
-  upstreams: Map<string, UpstreamState>,
-  peer: Peer,
-  state: UpstreamState,
-  plan: _DialPlan,
-  options: WebSocketProxyOptions,
-): void {
-  // The peer may have closed while an async plan (e.g. Node's `import("ws")`)
-  // was resolving — don't attach a stale upstream.
-  if (upstreams.get(peer.id) !== state) return;
-
   let ws: WebSocket;
   try {
     const protocols = _resolveProtocols(peer, options.forwardProtocol);
     const wsOptions = _resolveWsOptions(options, peer);
-    if (!wsOptions) {
-      // No extra options — the WHATWG-compatible `(url, protocols)` shape works
-      // on every runtime (including Deno's positional second argument).
-      ws = new plan.ctor(plan.url, protocols);
-    } else if (plan.optionsAsSecondArg) {
-      // Deno: `new WebSocket(url, { client, protocols, ... })`. Subprotocols
-      // travel inside the options object rather than as a positional argument.
-      const opts: Record<string, unknown> = { ...wsOptions };
-      if (protocols) opts.protocols = protocols;
-      ws = new (plan.ctor as unknown as new (url: URL, opts: Record<string, unknown>) => WebSocket)(
-        plan.url,
-        opts,
-      );
-    } else {
-      // `ws`/`undici` accept a third options object where `headers`,
-      // `webSocketOptions`, etc. are honored. The WHATWG browser global ignores
-      // the extra argument, which is documented for those options.
-      ws = new (plan.ctor as unknown as new (
-        url: URL,
-        protocols: string[] | undefined,
-        opts: Record<string, unknown>,
-      ) => WebSocket)(plan.url, protocols, wsOptions);
-    }
+    // The runtime `#websocket` client (or a caller-supplied `WebSocket`) owns
+    // any scheme/argument specifics: it dials `ws+unix:` per runtime and, on
+    // Deno, relays options to the constructor's second argument. So a uniform
+    // `(url, protocols)` — plus a third options object when configured — works
+    // here. The WHATWG browser global simply ignores the extra argument.
+    ws = wsOptions
+      ? new (WebSocketCtor as unknown as new (
+          url: URL,
+          protocols: string[] | undefined,
+          opts: Record<string, unknown>,
+        ) => WebSocket)(url, protocols, wsOptions)
+      : new WebSocketCtor(url, protocols);
     ws.binaryType = "arraybuffer";
   } catch {
     // Bad target URL, disallowed scheme, invalid subprotocol token,
@@ -523,60 +468,6 @@ function _resolveWsOptions(
   const merged: Record<string, unknown> = { ...extra };
   if (resolvedHeaders) merged.headers = resolvedHeaders;
   return merged;
-}
-
-// Choose how to dial `url`. Plain `ws:`/`wss:` targets (and any target with an
-// explicit `WebSocket` constructor) dial as-is. A `ws+unix:` target is delegated
-// to the matching per-runtime `crossws/websocket` client, which knows how to
-// reach a Unix socket on its runtime, so it works out of the box:
-//
-// - Bun: its global `WebSocket` dials `ws+unix:` natively — pass through.
-// - Node: the `crossws/websocket` Node client routes `ws+unix:` through `ws`.
-// - Deno: the `crossws/websocket` Deno client routes it through a unix
-//   `Deno.createHttpClient` transport.
-//
-// The wrappers are imported lazily so their `ws`/Deno-specific code never enters
-// the eager graph of the runtime-agnostic `crossws` entry (which browsers and
-// Workers also load). Returns a promise only for those lazy imports; the plain
-// and Bun paths resolve synchronously.
-function _planDial(
-  url: URL,
-  options: WebSocketProxyOptions,
-  WebSocketCtor: typeof WebSocket,
-): _DialPlan | Promise<_DialPlan> {
-  const runtime = globalThis as {
-    Bun?: unknown;
-    Deno?: unknown;
-    process?: { versions?: { node?: string } };
-  };
-
-  // Deno's global `WebSocket` takes options as its second argument, unlike the
-  // WHATWG/`ws`/`undici` third — flag it so `webSocketOptions` (e.g. a unix
-  // `client`) reaches Deno. A custom `WebSocket` is assumed to follow the
-  // WHATWG/`ws` third-argument shape.
-  const optionsAsSecondArg = !options.WebSocket && !!runtime.Deno;
-
-  // A caller-supplied constructor is used verbatim — the user opted into
-  // whatever scheme handling it provides (e.g. `ws`'s `ws+unix:` support).
-  if (url.protocol !== "ws+unix:" || options.WebSocket) {
-    return { ctor: WebSocketCtor, url, optionsAsSecondArg };
-  }
-
-  if (runtime.Bun) {
-    return { ctor: WebSocketCtor, url };
-  }
-
-  if (runtime.Deno) {
-    return import("./websocket/deno.ts").then((mod) => ({ ctor: mod.default, url }));
-  }
-
-  if (runtime.process?.versions?.node) {
-    return import("./websocket/node.ts").then((mod) => ({ ctor: mod.default, url }));
-  }
-
-  throw new Error(
-    `crossws proxy cannot dial a \`ws+unix:\` target on this runtime — pass a \`WebSocket\` option that supports the scheme.`,
-  );
 }
 
 /** @internal exported for tests */

--- a/src/websocket/bun.ts
+++ b/src/websocket/bun.ts
@@ -1,0 +1,8 @@
+// `crossws/websocket` entry for Bun.
+//
+// Bun's global `WebSocket` dials `ws:`, `wss:`, and `ws+unix:` natively, so no
+// wrapping is needed — this re-exports the global as the Bun runtime entry
+// (kept as a dedicated file for parity with the Node/Deno wrappers).
+const WebSocket: typeof globalThis.WebSocket = globalThis.WebSocket;
+
+export default WebSocket;

--- a/src/websocket/deno.ts
+++ b/src/websocket/deno.ts
@@ -1,0 +1,45 @@
+// `crossws/websocket` entry for Deno.
+//
+// Deno's global `WebSocket` dials `ws:`/`wss:` out of the box but rejects the
+// `ws+unix://<socketPath>:<pathname>` scheme. This wrapper adds transparent
+// Unix-socket support: such URLs are rewritten to a plain `ws://` target and the
+// transport is routed through `Deno.createHttpClient`'s unstable unix `client`
+// (passed via Deno's second-argument options object). All other URLs — and the
+// subprotocols argument — pass through unchanged.
+
+const _WebSocket = globalThis.WebSocket;
+
+class DenoWebSocket extends _WebSocket {
+  constructor(url: string | URL, protocols?: string | string[]) {
+    const href = typeof url === "string" ? url : url.href;
+    if (!href.startsWith("ws+unix:")) {
+      super(url, protocols);
+      return;
+    }
+    const { socketPath, path } = _parseUnixTarget(href);
+    // `transport: "unix"` is an unstable option — run Deno with `--unstable-net`.
+    const client = Deno.createHttpClient({
+      proxy: { transport: "unix", path: socketPath },
+    } as unknown as Deno.CreateHttpClientOptions);
+    // Deno's `WebSocket` takes its options (including `client` and `protocols`)
+    // as the second argument, not the WHATWG/`ws` third.
+    const opts: Record<string, unknown> = { client };
+    if (protocols !== undefined) opts.protocols = protocols;
+    super(`ws://localhost${path}`, opts as unknown as string[]);
+  }
+}
+
+// Split a `ws+unix://<socketPath>:<pathname>` URL into its socket path and the
+// upstream request path. The socket path is everything before the first `:` in
+// the URL path; the rest (plus any query string) is the request path.
+function _parseUnixTarget(href: string): { socketPath: string; path: string } {
+  const { pathname, search } = new URL(href);
+  const raw = pathname + search;
+  const colon = raw.indexOf(":");
+  if (colon === -1) {
+    return { socketPath: raw, path: "/" };
+  }
+  return { socketPath: raw.slice(0, colon), path: raw.slice(colon + 1) || "/" };
+}
+
+export default DenoWebSocket as unknown as typeof globalThis.WebSocket;

--- a/src/websocket/deno.ts
+++ b/src/websocket/deno.ts
@@ -3,29 +3,36 @@
 // Deno's global `WebSocket` dials `ws:`/`wss:` out of the box but rejects the
 // `ws+unix://<socketPath>:<pathname>` scheme. This wrapper adds transparent
 // Unix-socket support: such URLs are rewritten to a plain `ws://` target and the
-// transport is routed through `Deno.createHttpClient`'s unstable unix `client`
-// (passed via Deno's second-argument options object). All other URLs — and the
-// subprotocols argument — pass through unchanged.
+// transport is routed through `Deno.createHttpClient`'s unstable unix `client`.
+//
+// Deno takes its dialing options (`client`, `protocols`, …) as the constructor's
+// *second* argument, unlike the WHATWG/`ws` third. So this wrapper also accepts a
+// third options object (e.g. a custom `client` from the proxy) and relays it into
+// Deno's second-argument form — plain `ws:`/`wss:` calls with no options keep the
+// native positional signature.
 
 const _WebSocket = globalThis.WebSocket;
 
 class DenoWebSocket extends _WebSocket {
-  constructor(url: string | URL, protocols?: string | string[]) {
+  constructor(url: string | URL, protocols?: string | string[], options?: Record<string, unknown>) {
     const href = typeof url === "string" ? url : url.href;
-    if (!href.startsWith("ws+unix:")) {
+    const isUnix = href.startsWith("ws+unix:");
+    if (!isUnix && !options) {
       super(url, protocols);
       return;
     }
-    const { socketPath, path } = _parseUnixTarget(href);
-    // `transport: "unix"` is an unstable option — run Deno with `--unstable-net`.
-    const client = Deno.createHttpClient({
-      proxy: { transport: "unix", path: socketPath },
-    } as unknown as Deno.CreateHttpClientOptions);
-    // Deno's `WebSocket` takes its options (including `client` and `protocols`)
-    // as the second argument, not the WHATWG/`ws` third.
-    const opts: Record<string, unknown> = { client };
+    const opts: Record<string, unknown> = { ...options };
     if (protocols !== undefined) opts.protocols = protocols;
-    super(`ws://localhost${path}`, opts as unknown as string[]);
+    if (isUnix) {
+      const { socketPath, path } = _parseUnixTarget(href);
+      // `transport: "unix"` is an unstable option — run Deno with `--unstable-net`.
+      opts.client ??= Deno.createHttpClient({
+        proxy: { transport: "unix", path: socketPath },
+      } as unknown as Deno.CreateHttpClientOptions);
+      super(`ws://localhost${path}`, opts as unknown as string[]);
+      return;
+    }
+    super(url, opts as unknown as string[]);
   }
 }
 

--- a/src/websocket/node.ts
+++ b/src/websocket/node.ts
@@ -1,5 +1,25 @@
-import { WebSocket as _WebSocket } from "ws";
+import { WebSocket as WsWebSocket } from "ws";
 
-const Websocket: typeof globalThis.WebSocket = globalThis.WebSocket || _WebSocket;
+// `crossws/websocket` entry for Node.
+//
+// Node's native global `WebSocket` (undici) dials `ws:`/`wss:` but rejects the
+// `ws+unix:` scheme, and is absent on Node < 22. The `ws` client supports both,
+// so route `ws+unix:` — and everything, when there is no global — through `ws`,
+// keeping the native global for the common `ws:`/`wss:` path. The `Proxy` keeps
+// the native constructor's static members (`WebSocket.OPEN`, …) intact.
+const _global = globalThis.WebSocket as typeof globalThis.WebSocket | undefined;
 
-export default Websocket;
+const NodeWebSocket: typeof globalThis.WebSocket = _global
+  ? new Proxy(_global, {
+      construct(target, args) {
+        const url = args[0] as string | URL | undefined;
+        const href = typeof url === "string" ? url : (url?.href ?? "");
+        const Ctor = href.startsWith("ws+unix:")
+          ? (WsWebSocket as unknown as typeof _global)
+          : target;
+        return Reflect.construct(Ctor, args);
+      },
+    })
+  : (WsWebSocket as unknown as typeof globalThis.WebSocket);
+
+export default NodeWebSocket;

--- a/test/fixture/proxy-unix.bun.ts
+++ b/test/fixture/proxy-unix.bun.ts
@@ -1,0 +1,45 @@
+// Unix-socket proxy fixture for Bun. Spawned by test/proxy-runtimes.test.ts.
+// Run manually with: bun run ./proxy-unix.bun.ts
+
+import { unlinkSync } from "node:fs";
+import bunAdapter from "../../src/adapters/bun.ts";
+import { createWebSocketProxy, defineHooks } from "../../src/index.ts";
+
+const port = Number.parseInt(process.env.PORT || "") || 3001;
+const socketPath = `/tmp/crossws-proxy-unix-bun-${process.pid}.sock`;
+try {
+  unlinkSync(socketPath);
+} catch {
+  // no stale socket to clean up
+}
+
+// Upstream echo server bound to a unix socket.
+const upstream = bunAdapter({
+  hooks: defineHooks({
+    message(peer, message) {
+      peer.send(`echo:${message.text()}`);
+    },
+  }),
+});
+Bun.serve({
+  unix: socketPath,
+  websocket: upstream.websocket,
+  fetch: (request, server) =>
+    request.headers.get("upgrade") === "websocket"
+      ? upstream.handleUpgrade(request, server)
+      : new Response("ok"),
+});
+
+// TCP proxy dialing the unix upstream out of the box (Bun's native `ws+unix:`).
+const proxy = bunAdapter({
+  hooks: createWebSocketProxy({ target: `ws+unix://${socketPath}:/` }),
+});
+Bun.serve({
+  port,
+  hostname: "localhost",
+  websocket: proxy.websocket,
+  fetch: (request, server) =>
+    request.headers.get("upgrade") === "websocket"
+      ? proxy.handleUpgrade(request, server)
+      : new Response("ok"),
+});

--- a/test/fixture/proxy-unix.deno.ts
+++ b/test/fixture/proxy-unix.deno.ts
@@ -1,5 +1,9 @@
 // Unix-socket proxy fixture for Deno. Spawned by test/proxy-runtimes.test.ts.
 // Run manually with: deno run --unstable-byonm --unstable-net -A ./proxy-unix.deno.ts
+//
+// Exercises out-of-the-box `ws+unix:` proxying on Deno: crossws dials the target
+// through the per-runtime `crossws/websocket` Deno client (which routes the
+// transport via a unix `Deno.createHttpClient`), no custom `WebSocket` required.
 
 import denoAdapter from "../../src/adapters/deno.ts";
 import { createWebSocketProxy, defineHooks } from "../../src/index.ts";
@@ -31,7 +35,7 @@ Deno.serve({ path: socketPath }, (request, info) =>
     : new Response("ok"),
 );
 
-// TCP proxy dialing the unix upstream out of the box (Deno `client` transport).
+// TCP proxy dialing the unix upstream out of the box (Deno `crossws/websocket`).
 const proxy = denoAdapter({
   hooks: createWebSocketProxy({ target: `ws+unix://${socketPath}:/` }),
 });

--- a/test/fixture/proxy-unix.deno.ts
+++ b/test/fixture/proxy-unix.deno.ts
@@ -1,0 +1,42 @@
+// Unix-socket proxy fixture for Deno. Spawned by test/proxy-runtimes.test.ts.
+// Run manually with: deno run --unstable-byonm --unstable-net -A ./proxy-unix.deno.ts
+
+import denoAdapter from "../../src/adapters/deno.ts";
+import { createWebSocketProxy, defineHooks } from "../../src/index.ts";
+
+const port = Number.parseInt(Deno.env.get("PORT") || "") || 3001;
+const socketPath = `/tmp/crossws-proxy-unix-deno-${Deno.pid}.sock`;
+try {
+  Deno.removeSync(socketPath);
+} catch {
+  // no stale socket to clean up
+}
+
+// Upstream echo server bound to a unix socket.
+const upstream = denoAdapter({
+  hooks: defineHooks({
+    message(peer, message) {
+      peer.send(`echo:${message.text()}`);
+    },
+  }),
+});
+Deno.serve({ path: socketPath }, (request, info) =>
+  request.headers.get("upgrade") === "websocket"
+    ? // A unix listener's `remoteAddr` is a `UnixAddr`; the adapter only reads
+      // `remoteAddr` for a TCP-shaped address, so narrow it for the type-check.
+      upstream.handleUpgrade(
+        request,
+        info as unknown as Parameters<typeof upstream.handleUpgrade>[1],
+      )
+    : new Response("ok"),
+);
+
+// TCP proxy dialing the unix upstream out of the box (Deno `client` transport).
+const proxy = denoAdapter({
+  hooks: createWebSocketProxy({ target: `ws+unix://${socketPath}:/` }),
+});
+Deno.serve({ hostname: "localhost", port }, (request, info) =>
+  request.headers.get("upgrade") === "websocket"
+    ? proxy.handleUpgrade(request, info)
+    : new Response("ok"),
+);

--- a/test/fixture/ws-unix.bun.ts
+++ b/test/fixture/ws-unix.bun.ts
@@ -1,0 +1,55 @@
+// `crossws/websocket` (Bun wrapper) unix-socket fixture. Spawned by
+// test/websocket-runtimes.test.ts. Prints `WRAPPER_OK` on success.
+// Run manually with: bun run ./ws-unix.bun.ts
+
+import { unlinkSync } from "node:fs";
+import BunWebSocket from "../../src/websocket/bun.ts";
+
+const sock = `/tmp/crossws-ws-unix-bun-${process.pid}.sock`;
+try {
+  unlinkSync(sock);
+} catch {
+  // no stale socket to clean up
+}
+
+// Echo server bound to a unix socket.
+const server = Bun.serve({
+  unix: sock,
+  websocket: {
+    message(ws, msg) {
+      ws.send(`echo:${msg}`);
+    },
+  },
+  fetch(req, srv) {
+    return srv.upgrade(req) ? undefined : new Response("ok");
+  },
+});
+await new Promise((r) => setTimeout(r, 150));
+
+// Dial `ws+unix:` through the wrapper (Bun's global handles it natively).
+const ws = new BunWebSocket(`ws+unix://${sock}:/chat`);
+const result = await new Promise<string>((resolve) => {
+  const to = setTimeout(() => resolve("TIMEOUT"), 3000);
+  ws.onopen = () => ws.send("hello");
+  ws.onmessage = (e) => {
+    clearTimeout(to);
+    resolve(String(e.data));
+  };
+  ws.onerror = () => {
+    clearTimeout(to);
+    resolve("ERROR");
+  };
+});
+
+server.stop(true);
+try {
+  unlinkSync(sock);
+} catch {
+  // best-effort cleanup
+}
+if (result === "echo:hello") {
+  console.log("WRAPPER_OK");
+  process.exit(0);
+}
+console.error("WRAPPER_FAIL:", result);
+process.exit(1);

--- a/test/fixture/ws-unix.deno.ts
+++ b/test/fixture/ws-unix.deno.ts
@@ -1,0 +1,50 @@
+// `crossws/websocket` (Deno wrapper) unix-socket fixture. Spawned by
+// test/websocket-runtimes.test.ts. Prints `WRAPPER_OK` on success.
+// Run manually with: deno run --unstable-byonm --unstable-net -A ./ws-unix.deno.ts
+
+import DenoWebSocket from "../../src/websocket/deno.ts";
+
+const sock = `/tmp/crossws-ws-unix-deno-${Deno.pid}.sock`;
+try {
+  Deno.removeSync(sock);
+} catch {
+  // no stale socket to clean up
+}
+
+// Echo server bound to a unix socket.
+Deno.serve({ path: sock }, (req) => {
+  if (req.headers.get("upgrade") === "websocket") {
+    const { socket, response } = Deno.upgradeWebSocket(req);
+    socket.onmessage = (e) => socket.send(`echo:${e.data}`);
+    return response;
+  }
+  return new Response("ok");
+});
+await new Promise((r) => setTimeout(r, 150));
+
+// Dial `ws+unix:` through the wrapper — no custom client wiring at the call site.
+const ws = new DenoWebSocket(`ws+unix://${sock}:/chat`);
+const result = await new Promise<string>((resolve) => {
+  const to = setTimeout(() => resolve("TIMEOUT"), 3000);
+  ws.onopen = () => ws.send("hello");
+  ws.onmessage = (e) => {
+    clearTimeout(to);
+    resolve(String(e.data));
+  };
+  ws.onerror = () => {
+    clearTimeout(to);
+    resolve("ERROR");
+  };
+});
+
+try {
+  Deno.removeSync(sock);
+} catch {
+  // best-effort cleanup
+}
+if (result === "echo:hello") {
+  console.log("WRAPPER_OK");
+  Deno.exit(0);
+}
+console.error("WRAPPER_FAIL:", result);
+Deno.exit(1);

--- a/test/proxy-runtimes.test.ts
+++ b/test/proxy-runtimes.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
+import { execa, type ResultPromise } from "execa";
+import { fileURLToPath } from "node:url";
+import { getRandomPort, waitForPort } from "get-port-please";
+import { wsConnect } from "./_utils.ts";
+
+// Cross-runtime coverage for out-of-the-box `ws+unix:` proxying. Node is covered
+// in-process by proxy.test.ts; here we spawn real Deno and Bun processes running
+// a fixture that proxies (over TCP) to an echo upstream bound to a unix socket,
+// exercising each runtime's native dialing strategy end to end.
+const fixtureDir = fileURLToPath(new URL("fixture", import.meta.url));
+
+function unixProxySuite(runtime: string, cmd: string) {
+  describe(`proxy unix (${runtime})`, () => {
+    let child: ResultPromise | undefined;
+    let url: string;
+
+    beforeAll(async () => {
+      const port = await getRandomPort("localhost");
+      url = `ws://localhost:${port}/`;
+      const [bin, ...args] = cmd.replace("./", `${fixtureDir}/`).split(" ");
+      child = execa(bin!, args, { env: { PORT: String(port) } });
+      child.catch((error) => {
+        if (error.signal !== "SIGTERM") {
+          console.error(error);
+        }
+      });
+      if (process.env.TEST_DEBUG) {
+        child.stderr?.on("data", (chunk) => console.log(chunk.toString()));
+        child.stdout?.on("data", (chunk) => console.log(chunk.toString()));
+      }
+      await waitForPort(port, { host: "localhost", delay: 50, retries: 100 });
+    });
+
+    afterAll(async () => {
+      await child?.kill();
+    });
+
+    test("proxies text frames to the unix-socket upstream", async () => {
+      const ws = await wsConnect(url);
+      await ws.send("hello");
+      expect(await ws.next()).toBe("echo:hello");
+    });
+  });
+}
+
+unixProxySuite("deno", "deno run --unstable-byonm --unstable-net -A ./proxy-unix.deno.ts");
+unixProxySuite("bun", "bun run ./proxy-unix.bun.ts");

--- a/test/proxy-runtimes.test.ts
+++ b/test/proxy-runtimes.test.ts
@@ -7,7 +7,7 @@ import { wsConnect } from "./_utils.ts";
 // Cross-runtime coverage for out-of-the-box `ws+unix:` proxying. Node is covered
 // in-process by proxy.test.ts; here we spawn real Deno and Bun processes running
 // a fixture that proxies (over TCP) to an echo upstream bound to a unix socket,
-// exercising each runtime's native dialing strategy end to end.
+// exercising each runtime's `crossws/websocket` dialing strategy end to end.
 const fixtureDir = fileURLToPath(new URL("fixture", import.meta.url));
 
 function unixProxySuite(runtime: string, cmd: string) {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -8,12 +8,7 @@ import { getRandomPort, waitForPort } from "get-port-please";
 import { WebSocket as WsWebSocket } from "ws";
 import nodeAdapter from "../src/adapters/node.ts";
 import { createWebSocketProxy, defineHooks } from "../src/index.ts";
-import {
-  _normalizeOutgoingCode,
-  _parseUnixTarget,
-  _remapIncomingCode,
-  _resolveProtocols,
-} from "../src/proxy.ts";
+import { _normalizeOutgoingCode, _remapIncomingCode, _resolveProtocols } from "../src/proxy.ts";
 import { wsConnect } from "./_utils.ts";
 
 describe("createWebSocketProxy", () => {
@@ -671,30 +666,6 @@ describe("createWebSocketProxy internals", () => {
     for (const code of [1001, 1005, 1006, 1008, 1011, 1015, 2999, 5000]) {
       expect(_normalizeOutgoingCode(code)).toBe(1000);
     }
-  });
-
-  test("_parseUnixTarget splits socket path from request path", () => {
-    const parse = (s: string) => _parseUnixTarget(new URL(s));
-    // Absolute socket path + request path.
-    expect(parse("ws+unix:///run/app.sock:/chat")).toEqual({
-      socketPath: "/run/app.sock",
-      path: "/chat",
-    });
-    // Query string is carried onto the request path.
-    expect(parse("ws+unix:///run/app.sock:/chat?room=1")).toEqual({
-      socketPath: "/run/app.sock",
-      path: "/chat?room=1",
-    });
-    // Missing request path defaults to "/".
-    expect(parse("ws+unix:///run/app.sock:")).toEqual({
-      socketPath: "/run/app.sock",
-      path: "/",
-    });
-    // No colon at all — the whole path is the socket path.
-    expect(parse("ws+unix:///run/app.sock")).toEqual({
-      socketPath: "/run/app.sock",
-      path: "/",
-    });
   });
 
   test("_remapIncomingCode rewrites reserved pseudo-codes before peer close", () => {

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -1,9 +1,19 @@
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { createServer, Server } from "node:http";
+import { existsSync, unlinkSync } from "node:fs";
+import { connect as netConnect } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { getRandomPort, waitForPort } from "get-port-please";
+import { WebSocket as WsWebSocket } from "ws";
 import nodeAdapter from "../src/adapters/node.ts";
 import { createWebSocketProxy, defineHooks } from "../src/index.ts";
-import { _normalizeOutgoingCode, _remapIncomingCode, _resolveProtocols } from "../src/proxy.ts";
+import {
+  _normalizeOutgoingCode,
+  _parseUnixTarget,
+  _remapIncomingCode,
+  _resolveProtocols,
+} from "../src/proxy.ts";
 import { wsConnect } from "./_utils.ts";
 
 describe("createWebSocketProxy", () => {
@@ -274,6 +284,138 @@ describe("createWebSocketProxy", () => {
     }
   });
 
+  test("proxies to a unix-socket upstream out of the box (no custom WebSocket)", async () => {
+    // A `ws+unix://<socketPath>:<pathname>` target works without any custom
+    // `WebSocket` constructor: the proxy picks the right per-runtime dialing
+    // strategy internally. On this Node test runner that means a lazy
+    // `import("ws")` (Node's global undici WebSocket rejects the scheme).
+    const socketPath = join(tmpdir(), `crossws-proxy-unix-${process.pid}.sock`);
+    if (existsSync(socketPath)) unlinkSync(socketPath);
+
+    // Upstream echo server bound to the unix socket instead of a TCP port.
+    const unixUpstream = nodeAdapter({
+      hooks: defineHooks({
+        message(peer, message) {
+          peer.send(`echo:${message.text()}`);
+        },
+      }),
+    });
+    const unixUpstreamServer = createServer((_req, res) => res.end("ok"));
+    unixUpstreamServer.on("upgrade", unixUpstream.handleUpgrade);
+    await new Promise<void>((resolve) => unixUpstreamServer.listen(socketPath, resolve));
+
+    // No `WebSocket` option — the proxy resolves the dialer per runtime.
+    const unixProxy = nodeAdapter({
+      hooks: createWebSocketProxy({
+        target: `ws+unix://${socketPath}:/chat`,
+      }),
+    });
+    const server = createServer((_req, res) => res.end("ok"));
+    server.on("upgrade", unixProxy.handleUpgrade);
+    const port = await getRandomPort("localhost");
+    await new Promise<void>((resolve) => server.listen(port, resolve));
+    await waitForPort(port);
+    try {
+      const ws = await wsConnect(`ws://localhost:${port}/`);
+      await ws.send("unix");
+      expect(await ws.next()).toBe("echo:unix");
+    } finally {
+      server.closeAllConnections?.();
+      server.close();
+      unixUpstreamServer.closeAllConnections?.();
+      unixUpstreamServer.close();
+      if (existsSync(socketPath)) unlinkSync(socketPath);
+    }
+  });
+
+  test("proxies to a unix-socket upstream with an explicit ws WebSocket", async () => {
+    // An explicit `WebSocket` constructor is honored verbatim (bypassing the
+    // per-runtime strategy) — the `ws` client dials `ws+unix:` directly.
+    const socketPath = join(tmpdir(), `crossws-proxy-unix-explicit-${process.pid}.sock`);
+    if (existsSync(socketPath)) unlinkSync(socketPath);
+
+    const unixUpstream = nodeAdapter({
+      hooks: defineHooks({
+        message(peer, message) {
+          peer.send(`echo:${message.text()}`);
+        },
+      }),
+    });
+    const unixUpstreamServer = createServer((_req, res) => res.end("ok"));
+    unixUpstreamServer.on("upgrade", unixUpstream.handleUpgrade);
+    await new Promise<void>((resolve) => unixUpstreamServer.listen(socketPath, resolve));
+
+    const unixProxy = nodeAdapter({
+      hooks: createWebSocketProxy({
+        target: `ws+unix://${socketPath}:/`,
+        WebSocket: WsWebSocket as unknown as typeof WebSocket,
+      }),
+    });
+    const server = createServer((_req, res) => res.end("ok"));
+    server.on("upgrade", unixProxy.handleUpgrade);
+    const port = await getRandomPort("localhost");
+    await new Promise<void>((resolve) => server.listen(port, resolve));
+    await waitForPort(port);
+    try {
+      const ws = await wsConnect(`ws://localhost:${port}/`);
+      await ws.send("unix");
+      expect(await ws.next()).toBe("echo:unix");
+    } finally {
+      server.closeAllConnections?.();
+      server.close();
+      unixUpstreamServer.closeAllConnections?.();
+      unixUpstreamServer.close();
+      if (existsSync(socketPath)) unlinkSync(socketPath);
+    }
+  });
+
+  test("dials a unix socket via a webSocketOptions transport override", async () => {
+    // Some runtimes (Deno) reject the `ws+unix:` scheme and can only reach a
+    // unix socket by redirecting the transport through a constructor option
+    // (Deno's `client`). `webSocketOptions` is the escape hatch for that: here
+    // we keep a plain `ws://` target and inject `ws`'s `createConnection` to
+    // dial the socket — the same shape a Deno consumer would use for `client`.
+    const socketPath = join(tmpdir(), `crossws-proxy-wsopts-${process.pid}.sock`);
+    if (existsSync(socketPath)) unlinkSync(socketPath);
+
+    const unixUpstream = nodeAdapter({
+      hooks: defineHooks({
+        message(peer, message) {
+          peer.send(`echo:${message.text()}`);
+        },
+      }),
+    });
+    const unixUpstreamServer = createServer((_req, res) => res.end("ok"));
+    unixUpstreamServer.on("upgrade", unixUpstream.handleUpgrade);
+    await new Promise<void>((resolve) => unixUpstreamServer.listen(socketPath, resolve));
+
+    const optsProxy = nodeAdapter({
+      hooks: createWebSocketProxy({
+        target: "ws://localhost/",
+        WebSocket: WsWebSocket as unknown as typeof WebSocket,
+        webSocketOptions: () => ({
+          createConnection: () => netConnect({ path: socketPath }),
+        }),
+      }),
+    });
+    const server = createServer((_req, res) => res.end("ok"));
+    server.on("upgrade", optsProxy.handleUpgrade);
+    const port = await getRandomPort("localhost");
+    await new Promise<void>((resolve) => server.listen(port, resolve));
+    await waitForPort(port);
+    try {
+      const ws = await wsConnect(`ws://localhost:${port}/`);
+      await ws.send("via-opts");
+      expect(await ws.next()).toBe("echo:via-opts");
+    } finally {
+      server.closeAllConnections?.();
+      server.close();
+      unixUpstreamServer.closeAllConnections?.();
+      unixUpstreamServer.close();
+      if (existsSync(socketPath)) unlinkSync(socketPath);
+    }
+  });
+
   test("propagates upstream close code", async () => {
     const ws = await wsConnect(proxyURL, { skip: 1 });
     const closed = new Promise<CloseEvent>((resolve) => {
@@ -381,6 +523,81 @@ describe("createWebSocketProxy unit hooks", () => {
     });
   });
 
+  test("merges webSocketOptions into the constructor's third argument", () => {
+    const calls: Array<{ options: unknown }> = [];
+    class StubWS extends EventTarget {
+      binaryType = "arraybuffer";
+      readyState = 0;
+      constructor(_url: unknown, _protocols: unknown, options?: unknown) {
+        super();
+        calls.push({ options });
+      }
+      send(): void {}
+      close(): void {}
+    }
+    const peer = {
+      id: "p-opts",
+      request: new Request("http://localhost/", { headers: { cookie: "sid=abc" } }),
+      close() {},
+      send() {},
+    };
+
+    // A per-peer resolver's keys land in the third argument, and the dedicated
+    // `headers` option is applied on top of any `headers` key it returns.
+    const marker = { transport: "unix" };
+    const withResolver = createWebSocketProxy({
+      target: "ws://upstream.invalid/",
+      WebSocket: StubWS as unknown as typeof WebSocket,
+      connectTimeout: 0,
+      webSocketOptions: (p) => ({ client: marker, headers: { "x-ignored": p.id } }),
+      headers: (p) => ({ cookie: p.request?.headers.get("cookie") ?? "" }),
+    });
+    withResolver.open?.(peer as never);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]!.options).toEqual({
+      client: marker,
+      headers: { cookie: "sid=abc" },
+    });
+
+    // A static object works too, and passes through with no headers option.
+    calls.length = 0;
+    const withStatic = createWebSocketProxy({
+      target: "ws://upstream.invalid/",
+      WebSocket: StubWS as unknown as typeof WebSocket,
+      connectTimeout: 0,
+      webSocketOptions: { agent: false },
+    });
+    withStatic.open?.({ ...peer, id: "p-opts-static" } as never);
+    expect(calls[0]!.options).toEqual({ agent: false });
+  });
+
+  test("omits the third argument when neither headers nor webSocketOptions is set", () => {
+    const calls: Array<{ argc: number }> = [];
+    class StubWS extends EventTarget {
+      binaryType = "arraybuffer";
+      readyState = 0;
+      constructor(..._args: unknown[]) {
+        super();
+        calls.push({ argc: _args.length });
+      }
+      send(): void {}
+      close(): void {}
+    }
+    const hooks = createWebSocketProxy({
+      target: "ws://upstream.invalid/",
+      WebSocket: StubWS as unknown as typeof WebSocket,
+      connectTimeout: 0,
+    });
+    hooks.open?.({
+      id: "p-noopts",
+      request: new Request("http://localhost/"),
+      close() {},
+      send() {},
+    } as never);
+    // Only (url, protocols) — no third options object fabricated.
+    expect(calls).toEqual([{ argc: 2 }]);
+  });
+
   test("closes peer with 1011 when WebSocket constructor rejects the target", async () => {
     // The WHATWG `WebSocket` constructor throws `SyntaxError` for any
     // scheme other than `ws:`/`wss:`. The open hook must catch that
@@ -454,6 +671,30 @@ describe("createWebSocketProxy internals", () => {
     for (const code of [1001, 1005, 1006, 1008, 1011, 1015, 2999, 5000]) {
       expect(_normalizeOutgoingCode(code)).toBe(1000);
     }
+  });
+
+  test("_parseUnixTarget splits socket path from request path", () => {
+    const parse = (s: string) => _parseUnixTarget(new URL(s));
+    // Absolute socket path + request path.
+    expect(parse("ws+unix:///run/app.sock:/chat")).toEqual({
+      socketPath: "/run/app.sock",
+      path: "/chat",
+    });
+    // Query string is carried onto the request path.
+    expect(parse("ws+unix:///run/app.sock:/chat?room=1")).toEqual({
+      socketPath: "/run/app.sock",
+      path: "/chat?room=1",
+    });
+    // Missing request path defaults to "/".
+    expect(parse("ws+unix:///run/app.sock:")).toEqual({
+      socketPath: "/run/app.sock",
+      path: "/",
+    });
+    // No colon at all — the whole path is the socket path.
+    expect(parse("ws+unix:///run/app.sock")).toEqual({
+      socketPath: "/run/app.sock",
+      path: "/",
+    });
   });
 
   test("_remapIncomingCode rewrites reserved pseudo-codes before peer close", () => {

--- a/test/websocket-runtimes.test.ts
+++ b/test/websocket-runtimes.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "vitest";
+import { execa } from "execa";
+import { fileURLToPath } from "node:url";
+
+// Coverage for the runtime-specific `crossws/websocket` wrappers. Each fixture
+// spawns a real Deno/Bun process that dials a `ws+unix:` upstream through the
+// wrapper's constructor and prints `WRAPPER_OK` on a successful echo round-trip.
+const fixtureDir = fileURLToPath(new URL("fixture", import.meta.url));
+
+function wrapperSuite(runtime: string, cmd: string) {
+  describe(`crossws/websocket ws+unix (${runtime})`, () => {
+    test("dials a unix-socket upstream via the runtime wrapper", async () => {
+      const [bin, ...args] = cmd.replace("./", `${fixtureDir}/`).split(" ");
+      const result = await execa(bin!, args, { reject: false });
+      if (process.env.TEST_DEBUG) {
+        console.log(result.stdout, result.stderr);
+      }
+      expect(result.stdout).toContain("WRAPPER_OK");
+      expect(result.exitCode).toBe(0);
+    }, 20_000);
+  });
+}
+
+wrapperSuite("deno", "deno run --unstable-byonm --unstable-net -A ./ws-unix.deno.ts");
+wrapperSuite("bun", "bun run ./ws-unix.bun.ts");


### PR DESCRIPTION
Proxy to a Unix-socket upstream by returning a `ws+unix://<socketPath>:<pathname>` target — works out of the box on **Node, Bun, and Deno**, no custom `WebSocket` constructor required:

```ts
import { createWebSocketProxy } from "crossws";

const hooks = createWebSocketProxy({
  target: "ws+unix:///var/run/backend.sock:/chat",
});
```

The path before the `:` is the socket file; the path after it is the request path forwarded upstream.

## How it dials

The proxy dials through a single **static** import of the runtime WebSocket client:

```ts
import runtimeWebSocket from "crossws/websocket";
```

The `crossws/websocket` export conditions resolve the right client per runtime, and each client owns its own scheme handling — so the proxy has no runtime detection (`globalThis` checks) and no dynamic `import()`. Because the import is statically analyzable, a bundle built for a given runtime **tree-shakes the others** (`ws`/`node:*` never enter a Deno or browser bundle):

- **Bun** — global `WebSocket` dials `ws+unix:` natively.
- **Node** — global (undici) `WebSocket` rejects the scheme, so the Node client routes `ws+unix:` through [`ws`](https://github.com/websockets/ws) (bundled with crossws, no extra dependency), keeping the native global for `ws:`/`wss:`.
- **Deno** — global `WebSocket` rejects the scheme, so the Deno client routes the transport through [`Deno.createHttpClient`](https://docs.deno.com/api/deno/~/Deno.createHttpClient)'s unix `client` (unstable — needs `--unstable-net`).

## `crossws/websocket` wrappers

New per-runtime entries make `ws+unix:` (and, on Deno, custom dialing options) work through the `crossws/websocket` client itself, not just the proxy:

- `src/websocket/deno.ts` — subclasses the global; rewrites `ws+unix:` to a plain `ws://` target dialed through a unix `Deno.createHttpClient`, and relays a third options object into Deno's second-argument form.
- `src/websocket/node.ts` — a `Proxy` over the native global that routes `ws+unix:` (and everything on Node < 22) through `ws`, preserving the global's static members.
- `src/websocket/bun.ts` — re-exports the global (Bun dials `ws+unix:` natively).

The `./websocket` `bun`/`deno` export conditions now point at these wrappers (were `native`). `crossws/websocket` is kept external in the build (a bare specifier in `dist`) so the consumer's runtime/bundler resolves the condition; `prepare: obuild --stub` makes `dist` re-export `src` so in-repo dev and tests resolve to source without a build.

## `webSocketOptions`

Adds a `webSocketOptions` option (static or per-peer resolver) that passes extra dialing options to the upstream client — the escape hatch for transport options the URL can't express (e.g. `ws`/`undici` `createConnection`/`dispatcher`/`agent`, or a custom `Deno.createHttpClient` `client`). Merged with `headers`, with `headers` winning on conflict.

## Tests

- Node `ws+unix:` proxy path covered in-process (`test/proxy.test.ts`), routed through the Node client.
- Deno + Bun out-of-the-box proxy path covered by spawned fixtures (`test/proxy-runtimes.test.ts`).
- `crossws/websocket` Deno + Bun wrappers covered by spawned fixtures (`test/websocket-runtimes.test.ts`).
- Full suite green (220 passed / 6 skipped); build verified to keep `ws`/`node:*` out of the Deno/browser wrappers and the eager edge graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)