### PR TITLE
fix(client): honor 3rd-arg options (headers) on bun and node

### DIFF
--- a/docs/1.guide/9.client.md
+++ b/docs/1.guide/9.client.md
@@ -1,0 +1,88 @@
+---
+icon: tabler:plug-connected
+---
+
+# WebSocket Client
+
+> A per-runtime WebSocket **client** for dialing upstream servers with one consistent signature.
+
+Every runtime exposes a slightly different `WebSocket` constructor for **dialing** a server: Bun and Deno take their dialing options as the constructor's second argument, the WHATWG/`ws` clients take a third, and only some accept the `ws+unix:` scheme or custom upgrade headers. crossws smooths this over with the `crossws/websocket` subpath — a thin per-runtime client that dials `ws:`, `wss:`, and `ws+unix:` upstreams through one uniform `(url, protocols, options)` signature.
+
+This is the same client [the proxy](/guide/proxy) uses under the hood. Reach for it directly when you need to dial an upstream WebSocket yourself — for example from a custom hook — and want custom headers or Unix-socket support to work the same way on every runtime.
+
+> [!NOTE]
+> `crossws/websocket` is a **client** (it dials out). To accept incoming connections, use an [adapter](/adapters) or [`crossws/server`](/guide).
+
+## Usage
+
+Import the default export and construct it like a standard `WebSocket`:
+
+```ts
+import WebSocket from "crossws/websocket";
+
+const ws = new WebSocket("wss://echo.websocket.org");
+ws.onopen = () => ws.send("hello");
+ws.onmessage = (event) => console.log(event.data);
+```
+
+The returned instance is a standard [`WebSocket`](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket) — the same events (`open`, `message`, `close`, `error`), methods (`send`, `close`), and static members (`WebSocket.OPEN`, …) you already know.
+
+## Signature
+
+```ts
+new WebSocket(url, protocols?, options?);
+```
+
+- **`url`** — `string | URL`. The upstream to dial: `ws:`, `wss:`, or a [`ws+unix://<socketPath>:<pathname>`](#unix-domain-sockets) target.
+- **`protocols`** — `string | string[]` (optional). Subprotocol(s) offered during the handshake, exactly as the WHATWG constructor.
+- **`options`** — `Record<string, unknown>` (optional). Extra dialing options — most commonly custom upgrade `headers`. crossws relays this into whichever argument position the current runtime expects.
+
+The third `options` argument is the value the WHATWG browser constructor can't express. crossws makes it behave the same everywhere:
+
+```ts
+import WebSocket from "crossws/websocket";
+
+const ws = new WebSocket("wss://backend.example.com", undefined, {
+  headers: { authorization: "Bearer …" },
+});
+```
+
+> [!TIP]
+> When you call it with just `(url, protocols)` and no `options`, crossws keeps the runtime's native positional path — so option-less calls are identical to using the global `WebSocket` directly.
+
+## Per-runtime behavior
+
+crossws resolves a runtime-specific implementation through [export conditions](https://nodejs.org/api/packages.html#conditional-exports), so a bundle built for one runtime tree-shakes away the others (e.g. `ws` and `node:*` never enter a Deno or browser bundle):
+
+| Runtime | Implementation |
+| --- | --- |
+| **Bun** | Global `WebSocket` — dials `ws:`/`wss:`/`ws+unix:` natively. crossws relays `options` into Bun's second-argument form. |
+| **Node.js** | Global `WebSocket` (undici) for the common `ws:`/`wss:` path; routes through [`ws`](https://github.com/websockets/ws) (bundled, no extra dependency) whenever `options` are passed or the target is `ws+unix:` — and everywhere on Node < 22, which has no global. |
+| **Deno** | Global `WebSocket`; relays `options` into Deno's second-argument form, and rewrites `ws+unix:` targets through [`Deno.createHttpClient`](https://docs.deno.com/api/deno/~/Deno.createHttpClient)'s unix `client`. |
+| **Browser / Workers / edge** | The WHATWG global `WebSocket` verbatim. It has no third-argument options, so custom `headers` are silently ignored. |
+
+> [!IMPORTANT]
+> Custom `headers` (and other `options`) are honored on Bun, Deno, and Node — not in browsers, Cloudflare Workers, or other edge runtimes, whose WHATWG constructor drops them. Don't rely on upstream identity via headers there.
+
+## Unix domain sockets
+
+Dial an upstream listening on a Unix domain socket by passing a `ws+unix://<socketPath>:<pathname>` URL. This works **out of the box** on Node.js, Bun, and Deno:
+
+```ts
+import WebSocket from "crossws/websocket";
+
+const ws = new WebSocket("ws+unix:///var/run/backend.sock:/chat");
+```
+
+The path before the `:` is the socket file (`/var/run/backend.sock`); the path after it is the request path forwarded to the upstream (`/chat`).
+
+> [!NOTE]
+> On **Deno**, the unix transport uses `Deno.createHttpClient`, an **unstable** API — run Deno with the `--unstable-net` flag to enable it.
+
+## Relationship to the proxy
+
+[`createWebSocketProxy()`](/guide/proxy) dials every upstream through this client, which is why its [`headers`](/guide/proxy#forwarding-headers), [`webSocketOptions`](/guide/proxy#per-peer-constructor-options), and [`ws+unix:` targets](/guide/proxy#unix-domain-sockets) work uniformly across runtimes without a custom constructor. Passing an explicit [`WebSocket` option](/guide/proxy#custom-websocket-constructor) to the proxy opts out of this per-runtime handling and dials with your constructor verbatim.
+
+::read-more{to="/guide/proxy" title="WebSocket Proxy"}
+See the [WebSocket Proxy](/guide/proxy) guide for forwarding incoming connections to an upstream.
+::

--- a/src/websocket/bun.ts
+++ b/src/websocket/bun.ts
@@ -1,8 +1,26 @@
 // `crossws/websocket` entry for Bun.
 //
-// Bun's global `WebSocket` dials `ws:`, `wss:`, and `ws+unix:` natively, so no
-// wrapping is needed — this re-exports the global as the Bun runtime entry
-// (kept as a dedicated file for parity with the Node/Deno wrappers).
-const WebSocket: typeof globalThis.WebSocket = globalThis.WebSocket;
+// Bun's global `WebSocket` dials `ws:`, `wss:`, and `ws+unix:` natively, so the
+// scheme never needs rewriting. But Bun takes its dialing options (`headers`,
+// `protocols`, `tls`, …) as the constructor's *second* argument, unlike the
+// WHATWG/`ws` third. So this wrapper accepts a third options object (e.g. the
+// custom upgrade `headers` the proxy forwards) and relays it into Bun's
+// second-argument form — plain `ws:`/`wss:` calls with no options keep the
+// native positional signature and Bun's built-in `ws+unix:` support.
 
-export default WebSocket;
+const _WebSocket = globalThis.WebSocket;
+
+class BunWebSocket extends _WebSocket {
+  constructor(url: string | URL, protocols?: string | string[], options?: Record<string, unknown>) {
+    if (!options) {
+      super(url, protocols);
+      return;
+    }
+    // Bun merges `headers`/`protocols`/`tls`/… from a single options object.
+    const opts: Record<string, unknown> = { ...options };
+    if (protocols !== undefined) opts.protocols = protocols;
+    super(url, opts as unknown as string[]);
+  }
+}
+
+export default BunWebSocket as unknown as typeof globalThis.WebSocket;

--- a/src/websocket/node.ts
+++ b/src/websocket/node.ts
@@ -3,10 +3,16 @@ import { WebSocket as WsWebSocket } from "ws";
 // `crossws/websocket` entry for Node.
 //
 // Node's native global `WebSocket` (undici) dials `ws:`/`wss:` but rejects the
-// `ws+unix:` scheme, and is absent on Node < 22. The `ws` client supports both,
-// so route `ws+unix:` — and everything, when there is no global — through `ws`,
-// keeping the native global for the common `ws:`/`wss:` path. The `Proxy` keeps
-// the native constructor's static members (`WebSocket.OPEN`, …) intact.
+// `ws+unix:` scheme, reads its dialing options only from the constructor's
+// *second* argument (ignoring a third), and is absent on Node < 22. The `ws`
+// client supports the `ws+unix:` scheme and honors the WHATWG/`ws` third
+// options argument — where the proxy passes custom upgrade `headers` and other
+// `ws` dialing options. So route through `ws` when a third options argument is
+// present, for the `ws+unix:` scheme, or when there is no global; the native
+// global stays on the common option-less `ws:`/`wss:` path. This keeps the
+// `(url, protocols, options)` signature consistent with the Bun/Deno wrappers.
+// The `Proxy` keeps the native constructor's static members (`WebSocket.OPEN`,
+// …) intact.
 const _global = globalThis.WebSocket as typeof globalThis.WebSocket | undefined;
 
 const NodeWebSocket: typeof globalThis.WebSocket = _global
@@ -14,9 +20,8 @@ const NodeWebSocket: typeof globalThis.WebSocket = _global
       construct(target, args) {
         const url = args[0] as string | URL | undefined;
         const href = typeof url === "string" ? url : (url?.href ?? "");
-        const Ctor = href.startsWith("ws+unix:")
-          ? (WsWebSocket as unknown as typeof _global)
-          : target;
+        const useWs = href.startsWith("ws+unix:") || args[2] != null;
+        const Ctor = useWs ? (WsWebSocket as unknown as typeof _global) : target;
         return Reflect.construct(Ctor, args);
       },
     })

--- a/test/fixture/ws-unix.bun.ts
+++ b/test/fixture/ws-unix.bun.ts
@@ -12,22 +12,31 @@ try {
   // no stale socket to clean up
 }
 
-// Echo server bound to a unix socket.
+// Echo server bound to a unix socket. Echoes the payload plus the custom
+// upgrade header it received, so the fixture also asserts header forwarding.
+// The header is stashed in a closure (single connection) to avoid depending on
+// Bun's `ServerWebSocket.data` typing, which isn't loaded under the repo tsconfig.
+let seenHeader = "MISSING";
 const server = Bun.serve({
   unix: sock,
   websocket: {
     message(ws, msg) {
-      ws.send(`echo:${msg}`);
+      ws.send(`echo:${msg}:${seenHeader}`);
     },
   },
   fetch(req, srv) {
+    seenHeader = req.headers.get("x-custom") ?? "MISSING";
     return srv.upgrade(req) ? undefined : new Response("ok");
   },
 });
 await new Promise((r) => setTimeout(r, 150));
 
-// Dial `ws+unix:` through the wrapper (Bun's global handles it natively).
-const ws = new BunWebSocket(`ws+unix://${sock}:/chat`);
+// Dial `ws+unix:` through the wrapper (Bun handles the scheme natively), while
+// forwarding a custom upgrade header via the third options argument — Bun only
+// reads options from its second argument, so the wrapper must relay it there.
+const ws = new (BunWebSocket as unknown as {
+  new (url: string, protocols?: string | string[], options?: Record<string, unknown>): WebSocket;
+})(`ws+unix://${sock}:/chat`, undefined, { headers: { "x-custom": "HVAL" } });
 const result = await new Promise<string>((resolve) => {
   const to = setTimeout(() => resolve("TIMEOUT"), 3000);
   ws.onopen = () => ws.send("hello");
@@ -47,7 +56,7 @@ try {
 } catch {
   // best-effort cleanup
 }
-if (result === "echo:hello") {
+if (result === "echo:hello:HVAL") {
   console.log("WRAPPER_OK");
   process.exit(0);
 }

--- a/test/fixture/ws-unix.deno.ts
+++ b/test/fixture/ws-unix.deno.ts
@@ -11,19 +11,24 @@ try {
   // no stale socket to clean up
 }
 
-// Echo server bound to a unix socket.
+// Echo server bound to a unix socket. Echoes the payload plus the custom
+// upgrade header it received, so the fixture also asserts header forwarding.
 Deno.serve({ path: sock }, (req) => {
   if (req.headers.get("upgrade") === "websocket") {
+    const hdr = req.headers.get("x-custom") ?? "MISSING";
     const { socket, response } = Deno.upgradeWebSocket(req);
-    socket.onmessage = (e) => socket.send(`echo:${e.data}`);
+    socket.onmessage = (e) => socket.send(`echo:${e.data}:${hdr}`);
     return response;
   }
   return new Response("ok");
 });
 await new Promise((r) => setTimeout(r, 150));
 
-// Dial `ws+unix:` through the wrapper — no custom client wiring at the call site.
-const ws = new DenoWebSocket(`ws+unix://${sock}:/chat`);
+// Dial `ws+unix:` through the wrapper, forwarding a custom upgrade header via
+// the third options argument (the shape crossws's proxy uses).
+const ws = new (DenoWebSocket as unknown as {
+  new (url: string, protocols?: string | string[], options?: Record<string, unknown>): WebSocket;
+})(`ws+unix://${sock}:/chat`, undefined, { headers: { "x-custom": "HVAL" } });
 const result = await new Promise<string>((resolve) => {
   const to = setTimeout(() => resolve("TIMEOUT"), 3000);
   ws.onopen = () => ws.send("hello");
@@ -42,7 +47,7 @@ try {
 } catch {
   // best-effort cleanup
 }
-if (result === "echo:hello") {
+if (result === "echo:hello:HVAL") {
   console.log("WRAPPER_OK");
   Deno.exit(0);
 }

--- a/test/websocket-runtimes.test.ts
+++ b/test/websocket-runtimes.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "vitest";
 import { execa } from "execa";
 import { fileURLToPath } from "node:url";
+import { WebSocketServer } from "ws";
+import type { AddressInfo } from "node:net";
+import NodeWebSocket from "../src/websocket/node.ts";
 
 // Coverage for the runtime-specific `crossws/websocket` wrappers. Each fixture
 // spawns a real Deno/Bun process that dials a `ws+unix:` upstream through the
@@ -23,3 +26,45 @@ function wrapperSuite(runtime: string, cmd: string) {
 
 wrapperSuite("deno", "deno run --unstable-byonm --unstable-net -A ./ws-unix.deno.ts");
 wrapperSuite("bun", "bun run ./ws-unix.bun.ts");
+
+// Node runs the test process itself, so its wrapper is exercised in-process.
+// Node's native `WebSocket` (undici) reads dialing options only from its second
+// argument, so custom upgrade `headers` passed as the third argument — the shape
+// crossws's proxy uses — must be routed through `ws` by the wrapper.
+describe("crossws/websocket headers (node)", () => {
+  test("forwards a custom upgrade header via the third options argument", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    wss.on("connection", (ws, req) => {
+      ws.send(
+        `${req.headers["x-custom"] ?? "MISSING"}|${req.headers["sec-websocket-protocol"] ?? "NOPROTO"}`,
+      );
+    });
+    await new Promise((r) => wss.on("listening", r));
+    const { port } = wss.address() as AddressInfo;
+
+    try {
+      const result = await new Promise<string>((resolve) => {
+        const ws = new (NodeWebSocket as unknown as {
+          new (
+            url: string,
+            protocols?: string | string[],
+            options?: Record<string, unknown>,
+          ): WebSocket;
+        })(`ws://localhost:${port}/`, ["chat"], { headers: { "x-custom": "HVAL" } });
+        const to = setTimeout(() => resolve("TIMEOUT"), 3000);
+        ws.onmessage = (e) => {
+          clearTimeout(to);
+          resolve(String(e.data));
+          ws.close();
+        };
+        ws.onerror = () => {
+          clearTimeout(to);
+          resolve("ERROR");
+        };
+      });
+      expect(result).toBe("HVAL|chat");
+    } finally {
+      wss.close();
+    }
+  }, 10_000);
+});

--- a/test/websocket-runtimes.test.ts
+++ b/test/websocket-runtimes.test.ts
@@ -42,20 +42,19 @@ describe("crossws/websocket headers (node)", () => {
     await new Promise((r) => wss.on("listening", r));
     const { port } = wss.address() as AddressInfo;
 
+    const ws = new (NodeWebSocket as unknown as {
+      new (
+        url: string,
+        protocols?: string | string[],
+        options?: Record<string, unknown>,
+      ): WebSocket;
+    })(`ws://localhost:${port}/`, ["chat"], { headers: { "x-custom": "HVAL" } });
     try {
       const result = await new Promise<string>((resolve) => {
-        const ws = new (NodeWebSocket as unknown as {
-          new (
-            url: string,
-            protocols?: string | string[],
-            options?: Record<string, unknown>,
-          ): WebSocket;
-        })(`ws://localhost:${port}/`, ["chat"], { headers: { "x-custom": "HVAL" } });
         const to = setTimeout(() => resolve("TIMEOUT"), 3000);
         ws.onmessage = (e) => {
           clearTimeout(to);
           resolve(String(e.data));
-          ws.close();
         };
         ws.onerror = () => {
           clearTimeout(to);
@@ -64,6 +63,7 @@ describe("crossws/websocket headers (node)", () => {
       });
       expect(result).toBe("HVAL|chat");
     } finally {
+      ws.close();
       wss.close();
     }
   }, 10_000);


### PR DESCRIPTION
## Summary

The `crossws/websocket` subpath is the per-runtime WebSocket **client** the proxy (`src/proxy.ts`) uses to dial upstreams. The proxy calls it uniformly as `new WebSocket(url, protocols, options)`, passing custom upgrade `headers` and other dialing options in the **third** argument.

The problem: that signature was **not consistent across runtimes**. I verified each empirically (real Bun/Deno/Node processes dialing a real echo server):

| Runtime | Before | Issue |
|---|---|---|
| **Deno** | ✅ worked | Wrapper already relayed 3rd-arg options → Deno's 2nd-arg form |
| **Bun** | ❌ headers dropped | Wrapper re-exported the global; Bun reads options from its **2nd** arg, ignoring the 3rd |
| **Node** | ⚠️ partly broken | `ws+unix:` used `ws` (3rd-arg works), but the common `ws://`/`wss://` path used native **undici**, which also only reads options from its **2nd** arg |

So custom upgrade headers (a documented feature via the proxy's `headers` / `webSocketOptions` options) worked only on Deno and Node's unix-socket path — silently dropped on Bun and Node's regular path.

## Changes

- **`src/websocket/bun.ts`** — now a `BunWebSocket` subclass that relays a 3rd-arg options object into Bun's 2nd-arg form (`{ ...options, protocols }`), mirroring the existing Deno wrapper. Option-less calls keep the native positional path (and Bun's built-in `ws+unix:` support).
- **`src/websocket/node.ts`** — routes through `ws` whenever a 3rd options argument is present (`args[2] != null`), not just for `ws+unix:`. `ws` honors the WHATWG/`ws` 3rd-arg options plus its extra features (`agent`, `handshakeTimeout`, …); the native global stays on the common option-less path.

Now `new WebSocket(url, protocols, options)` behaves identically on node/bun/deno.

## Tests

- Extended the Bun & Deno `ws+unix` fixtures to also forward a custom header and assert it round-trips.
- Added an in-process Node parity test dialing a real `ws` server with 3rd-arg headers.

Full suite green: **221 passed / 6 skipped**, plus typecheck, lint, and format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)