### PR TITLE
feat(server): default `resolve` to app fetch `.crossws`

### DIFF
--- a/docs/1.guide/7.resolver.md
+++ b/docs/1.guide/7.resolver.md
@@ -68,7 +68,7 @@ serve(app, {
 
 With the default resolver, your app's `fetch` handler is called with the raw WebSocket **upgrade request** on connect. Keep two things in mind:
 
-- **Attach hooks via `.crossws`.** Hooks are read from the `crossws` property of the returned `Response`. If `fetch` returns a normal `Response` for an upgrade path (an HTML page, a `302` redirect, a `404`, …) without `.crossws`, the socket still completes its handshake but has **no hooks attached** — every message is silently dropped. Make sure the upgrade path returns a response carrying `.crossws`:
+- **Attach hooks via `.crossws`.** Hooks are read from the `crossws` property of the value returned for the upgrade request. If `fetch` returns a normal `Response` for an upgrade path (an HTML page, a `302` redirect, a `404`, …) without `.crossws`, the socket still completes its handshake but has **no hooks attached** — every message is silently dropped. Make sure the upgrade path returns hooks, either on a `Response`:
 
   ```js
   import { defineHooks } from "crossws";
@@ -88,6 +88,23 @@ With the default resolver, your app's `fetch` handler is called with the raw Web
     return new Response("Hello!"); // normal HTTP response
   }
   ```
+
+  …or, as a shortcut for the upgrade path, a plain object `{ crossws, headers }` (no `Response` needed). Any `headers` are sent on the WebSocket handshake response:
+
+  ```js
+  function fetch(req) {
+    if (req.headers.get("upgrade") === "websocket") {
+      return {
+        crossws: hooks,
+        headers: { "x-powered-by": "crossws" }, // optional handshake headers
+      };
+    }
+    return new Response("Hello!"); // normal HTTP response — must be a Response
+  }
+  ```
+
+  > [!NOTE]
+  > The plain-object form is only for upgrade requests. Non-upgrade paths must still return a real `Response`. An HTTP `Response`'s own headers are **not** applied to the handshake — use the `{ crossws, headers }` shortcut (or an `upgrade` hook returning `{ headers }`) to set handshake headers.
 
 - **`fetch` runs per connection, so keep it side-effect-safe.** Any auth, logging, metrics, or database work in `fetch` now executes once for every WebSocket upgrade. If a code path must run only for regular HTTP requests, branch on the `upgrade` header first.
 

--- a/docs/1.guide/7.resolver.md
+++ b/docs/1.guide/7.resolver.md
@@ -68,7 +68,7 @@ serve(app, {
 
 With the default resolver, your app's `fetch` handler is called with the raw WebSocket **upgrade request** on connect. Keep two things in mind:
 
-- **Attach hooks via `.crossws`.** Hooks are read from the `crossws` property of the value returned for the upgrade request. A non-`crossws` **error or redirect** response (any non-`2xx` status, e.g. `new Response("Unauthorized", { status: 401 })` or a `302`) is sent back to the client and the handshake is rejected — handy for auth. A **`2xx`** response without `.crossws` still completes the handshake but with **no hooks attached**, so every message is silently dropped. Make sure the upgrade path returns hooks, either on a `Response`:
+- **Attach hooks via `.crossws`.** Hooks are read from the `crossws` property of the value returned for the upgrade request. A non-`crossws` **error or redirect** response (any status that is not `2xx` or `101`, e.g. `new Response("Unauthorized", { status: 401 })` or a `302`) is sent back to the client and the handshake is rejected — handy for auth. A **`2xx`** (or `101`) response without `.crossws` still completes the handshake but with **no hooks attached**, so every message is silently dropped. Make sure the upgrade path returns hooks, either on a `Response`:
 
   ```js
   import { defineHooks } from "crossws";

--- a/docs/1.guide/7.resolver.md
+++ b/docs/1.guide/7.resolver.md
@@ -63,3 +63,32 @@ serve(app, {
 
 > [!NOTE]
 > Passing inline hooks directly (`ws({ message })`) opts out of the fetch-based default: those hooks run with zero per-event overhead instead.
+
+### Making your `fetch` handler upgrade-aware
+
+With the default resolver, your app's `fetch` handler is called with the raw WebSocket **upgrade request** on connect. Keep two things in mind:
+
+- **Attach hooks via `.crossws`.** Hooks are read from the `crossws` property of the returned `Response`. If `fetch` returns a normal `Response` for an upgrade path (an HTML page, a `302` redirect, a `404`, …) without `.crossws`, the socket still completes its handshake but has **no hooks attached** — every message is silently dropped. Make sure the upgrade path returns a response carrying `.crossws`:
+
+  ```js
+  import { defineHooks } from "crossws";
+
+  const hooks = defineHooks({
+    message(peer, message) {
+      peer.send(message.text());
+    },
+  });
+
+  function fetch(req) {
+    if (req.headers.get("upgrade") === "websocket") {
+      const res = new Response(null);
+      res.crossws = hooks; // opt this connection into WebSocket handling
+      return res;
+    }
+    return new Response("Hello!"); // normal HTTP response
+  }
+  ```
+
+- **`fetch` runs per connection, so keep it side-effect-safe.** Any auth, logging, metrics, or database work in `fetch` now executes once for every WebSocket upgrade. If a code path must run only for regular HTTP requests, branch on the `upgrade` header first.
+
+- **Throwing/rejecting fails the handshake.** If `fetch` throws (or rejects) on the upgrade request, the WebSocket handshake is rejected rather than left hanging. Throw a `Response` to control the rejection; otherwise the client sees a `500`. To reject an upgrade _gracefully_, prefer returning a response without `.crossws` (or a `4xx`) over throwing.

--- a/docs/1.guide/7.resolver.md
+++ b/docs/1.guide/7.resolver.md
@@ -39,3 +39,25 @@ const websocket = crossws({
 
 // Update reference to `resolveWebSocketHooks` later.
 ```
+
+## Server plugin
+
+When using the [`crossws/server`](/guide) plugin (srvx integration), `resolve` is **optional**. If you omit it, hooks are resolved by calling the server's own `fetch` handler and reading the `crossws` property off the returned `Response` (the srvx convention for attaching WebSocket hooks):
+
+```js
+import { plugin as ws } from "crossws/server";
+
+// No `resolve` needed — hooks come from the app's fetch response `.crossws`.
+serve(app, { plugins: [ws()] });
+```
+
+Provide `resolve` only to customize routing, e.g. to resolve hooks without invoking the app:
+
+```js
+serve(app, {
+  plugins: [ws({ resolve: (req) => resolveWebSocketHooks(req) })],
+});
+```
+
+> [!NOTE]
+> Passing inline hooks directly (`ws({ message })`) opts out of the fetch-based default: those hooks run with zero per-event overhead instead.

--- a/docs/1.guide/7.resolver.md
+++ b/docs/1.guide/7.resolver.md
@@ -68,7 +68,7 @@ serve(app, {
 
 With the default resolver, your app's `fetch` handler is called with the raw WebSocket **upgrade request** on connect. Keep two things in mind:
 
-- **Attach hooks via `.crossws`.** Hooks are read from the `crossws` property of the value returned for the upgrade request. If `fetch` returns a normal `Response` for an upgrade path (an HTML page, a `302` redirect, a `404`, …) without `.crossws`, the socket still completes its handshake but has **no hooks attached** — every message is silently dropped. Make sure the upgrade path returns hooks, either on a `Response`:
+- **Attach hooks via `.crossws`.** Hooks are read from the `crossws` property of the value returned for the upgrade request. A non-`crossws` **error or redirect** response (any non-`2xx` status, e.g. `new Response("Unauthorized", { status: 401 })` or a `302`) is sent back to the client and the handshake is rejected — handy for auth. A **`2xx`** response without `.crossws` still completes the handshake but with **no hooks attached**, so every message is silently dropped. Make sure the upgrade path returns hooks, either on a `Response`:
 
   ```js
   import { defineHooks } from "crossws";
@@ -108,4 +108,4 @@ With the default resolver, your app's `fetch` handler is called with the raw Web
 
 - **`fetch` runs per connection, so keep it side-effect-safe.** Any auth, logging, metrics, or database work in `fetch` now executes once for every WebSocket upgrade. If a code path must run only for regular HTTP requests, branch on the `upgrade` header first.
 
-- **Throwing/rejecting fails the handshake.** If `fetch` throws (or rejects) on the upgrade request, the WebSocket handshake is rejected rather than left hanging. Throw a `Response` to control the rejection; otherwise the client sees a `500`. To reject an upgrade _gracefully_, prefer returning a response without `.crossws` (or a `4xx`) over throwing.
+- **Throwing/rejecting fails the handshake.** If `fetch` throws (or rejects) on the upgrade request, the WebSocket handshake is rejected rather than left hanging. Throw a `Response` to control the rejection; otherwise the client sees a `500`. To reject an upgrade _gracefully_, prefer returning a non-`2xx` `Response` (which is rendered to the client) over throwing.

--- a/docs/1.guide/7.resolver.md
+++ b/docs/1.guide/7.resolver.md
@@ -59,5 +59,7 @@ serve(app, {
 });
 ```
 
+`resolve` is invoked **once per connection** — its result is cached against the connection for the lifetime of the peer — so the app's `fetch` runs on connect, not on every message.
+
 > [!NOTE]
 > Passing inline hooks directly (`ws({ message })`) opts out of the fetch-based default: those hooks run with zero per-event overhead instead.

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -116,8 +116,17 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
     handleUpgrade: async (nodeReq, socket, head, webRequest) => {
       const request = webRequest || new NodeReqProxy(nodeReq);
 
-      const { upgradeHeaders, endResponse, handled, context, namespace } =
-        await hooks.upgrade(request);
+      let upgraded: Awaited<ReturnType<typeof hooks.upgrade>>;
+      try {
+        upgraded = await hooks.upgrade(request);
+      } catch {
+        // `handleUpgrade` is invoked fire-and-forget from the server's
+        // `upgrade` listener, so a rejected `upgrade()` (e.g. the default
+        // resolver's app `fetch` throwing) would otherwise hang the socket and
+        // raise an unhandled rejection. Fail the handshake with a 500 instead.
+        return sendResponse(socket, new Response("Internal Server Error", { status: 500 }));
+      }
+      const { upgradeHeaders, endResponse, handled, context, namespace } = upgraded;
       if (endResponse) {
         return sendResponse(socket, endResponse);
       }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -6,6 +6,15 @@ import type { Message } from "./message.ts";
 export class AdapterHookable {
   options: AdapterOptions;
 
+  // Memoized `resolve` result per connection. `resolve` may be expensive — the
+  // default `crossws/server` resolver invokes the app's `fetch` handler — so it
+  // must run at most **once per connection**, not on every `callHook` (i.e. not
+  // on every message). The upgrade request and each peer's `request` identity
+  // are stable for the lifetime of a connection, so the resolved hooks are
+  // cached against that object and reused for every subsequent event. Keyed
+  // weakly so entries are released when the request/peer is garbage collected.
+  #resolveCache = new WeakMap<object, MaybePromise<Partial<Hooks> | undefined>>();
+
   constructor(options?: AdapterOptions) {
     this.options = options || {};
   }
@@ -19,9 +28,21 @@ export class AdapterHookable {
     const globalHook = this.options.hooks?.[name];
     const globalPromise = globalHook?.(arg1 as any, arg2 as any);
 
-    // Resolve hooks for request
+    const resolve = this.options.resolve;
+    if (!resolve) {
+      return globalPromise as any; // Fast path: no resolver configured
+    }
+
+    // Resolve hooks for the connection, memoized by the stable request/peer
+    // identity so `resolve` runs once per connection instead of per event.
     const request = (arg1 as Peer).request || arg1;
-    const resolveHooksPromise = this.options.resolve?.(request);
+    let resolveHooksPromise: MaybePromise<Partial<Hooks> | undefined>;
+    if (this.#resolveCache.has(request)) {
+      resolveHooksPromise = this.#resolveCache.get(request);
+    } else {
+      resolveHooksPromise = resolve(request);
+      this.#resolveCache.set(request, resolveHooksPromise);
+    }
     if (!resolveHooksPromise) {
       return globalPromise as any; // Fast path: no hooks to resolve
     }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -49,6 +49,18 @@ export class AdapterHookable {
     } else {
       resolveHooksPromise = resolve(request);
       this.#resolveCache.set(cacheKey, resolveHooksPromise);
+      // Don't let a rejected `resolve` poison the whole connection: evict the
+      // failed entry so a later event can retry and recover from a transient
+      // error (e.g. the default resolver's `fetch` failing once). Guarded so a
+      // concurrent re-resolve isn't clobbered. This `catch` is a separate branch
+      // and does not swallow the rejection seen by the hook resolution below.
+      if (resolveHooksPromise instanceof Promise) {
+        resolveHooksPromise.catch(() => {
+          if (this.#resolveCache.get(cacheKey) === resolveHooksPromise) {
+            this.#resolveCache.delete(cacheKey);
+          }
+        });
+      }
     }
     if (!resolveHooksPromise) {
       return globalPromise as any; // Fast path: no hooks to resolve

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -8,11 +8,13 @@ export class AdapterHookable {
 
   // Memoized `resolve` result per connection. `resolve` may be expensive — the
   // default `crossws/server` resolver invokes the app's `fetch` handler — so it
-  // must run at most **once per connection**, not on every `callHook` (i.e. not
-  // on every message). The upgrade request and each peer's `request` identity
-  // are stable for the lifetime of a connection, so the resolved hooks are
-  // cached against that object and reused for every subsequent event. Keyed
-  // weakly so entries are released when the request/peer is garbage collected.
+  // must run **exactly once per connection**, not on every `callHook` (i.e. not
+  // on every message). The cache is keyed by the connection's `context` object,
+  // which `upgrade()` creates and every adapter re-exposes verbatim as
+  // `peer.context`. That single shared identity spans both the `upgrade` event
+  // and every later peer event, so one `resolve` call serves the whole
+  // connection. Keyed weakly so entries are released when the connection is
+  // garbage collected.
   #resolveCache = new WeakMap<object, MaybePromise<Partial<Hooks> | undefined>>();
 
   constructor(options?: AdapterOptions) {
@@ -23,6 +25,10 @@ export class AdapterHookable {
     name: N,
     arg1: Parameters<Hooks[N]>[0],
     arg2?: Parameters<Hooks[N]>[1],
+    // The connection's `context` object, used as the per-connection cache key.
+    // Passed explicitly by `upgrade()` (no peer exists yet); for peer events it
+    // is derived from `peer.context`, which is the same object.
+    connection?: object,
   ): MaybePromise<ReturnType<Hooks[N]>> {
     // Call global hook first
     const globalHook = this.options.hooks?.[name];
@@ -33,15 +39,16 @@ export class AdapterHookable {
       return globalPromise as any; // Fast path: no resolver configured
     }
 
-    // Resolve hooks for the connection, memoized by the stable request/peer
+    // Resolve hooks for the connection, memoized by the shared `context`
     // identity so `resolve` runs once per connection instead of per event.
     const request = (arg1 as Peer).request || arg1;
+    const cacheKey = connection || (arg1 as Peer).context || request;
     let resolveHooksPromise: MaybePromise<Partial<Hooks> | undefined>;
-    if (this.#resolveCache.has(request)) {
-      resolveHooksPromise = this.#resolveCache.get(request);
+    if (this.#resolveCache.has(cacheKey)) {
+      resolveHooksPromise = this.#resolveCache.get(cacheKey);
     } else {
       resolveHooksPromise = resolve(request);
-      this.#resolveCache.set(request, resolveHooksPromise);
+      this.#resolveCache.set(cacheKey, resolveHooksPromise);
     }
     if (!resolveHooksPromise) {
       return globalPromise as any; // Fast path: no hooks to resolve
@@ -72,7 +79,14 @@ export class AdapterHookable {
     const context = request.context || {};
 
     try {
-      const res = await this.callHook("upgrade", request as Request & { context?: PeerContext });
+      // Seed the per-connection resolve cache against `context` so every later
+      // peer event on this connection reuses this single `resolve` call.
+      const res = await this.callHook(
+        "upgrade",
+        request as Request & { context?: PeerContext },
+        undefined,
+        context,
+      );
       if (!res) {
         return { context, namespace };
       }

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -47,7 +47,17 @@ export class AdapterHookable {
     if (this.#resolveCache.has(cacheKey)) {
       resolveHooksPromise = this.#resolveCache.get(cacheKey);
     } else {
-      resolveHooksPromise = resolve(request);
+      // `resolve` may throw *synchronously* (e.g. the default resolver's
+      // `fetch(req)` throwing before it returns a promise). Normalize that to a
+      // rejected promise so it flows through the same eviction/`.catch` path as
+      // an async rejection, instead of escaping as a synchronous throw — which,
+      // on the fire-and-forget event call sites (message/close/…), would surface
+      // as an uncaught exception rather than a handled rejection.
+      try {
+        resolveHooksPromise = resolve(request);
+      } catch (error) {
+        resolveHooksPromise = Promise.reject(error);
+      }
       this.#resolveCache.set(cacheKey, resolveHooksPromise);
       // Don't let a rejected `resolve` poison the whole connection: evict the
       // failed entry so a later event can retry and recover from a transient

--- a/src/server/_resolve.ts
+++ b/src/server/_resolve.ts
@@ -72,11 +72,13 @@ function hooksFromFetchResult(res: unknown): Partial<Hooks> | undefined {
     // client and fail the handshake) instead of silently upgrading a
     // handler-less socket — e.g. an app returning
     // `new Response("Unauthorized", { status: 401 })` on the upgrade path.
-    if (!res.ok) {
+    // `101` (Switching Protocols, as produced by e.g. Cloudflare's
+    // `WebSocketPair`) signals an upgrade, so it is not treated as an error.
+    if (!res.ok && res.status !== 101) {
       return { upgrade: () => res };
     }
-    // A plain 2xx response without hooks: the app didn't opt into WebSockets for
-    // this request; upgrade with no hooks and release the body.
+    // A `2xx`/`101` response without hooks: proceed with the upgrade but attach
+    // no hooks; the response body is unused, so release it.
     res.body?.cancel().catch(() => {});
     return undefined;
   }

--- a/src/server/_resolve.ts
+++ b/src/server/_resolve.ts
@@ -44,7 +44,8 @@ export function defaultResolve(server: Server, wsOpts: WSOptions): WSOptions["re
     throw new Error("[crossws] server has no fetch handler to resolve WebSocket hooks from");
   }
 
-  return (req) => Promise.resolve(fetch(req)).then((res) => hooksFromFetchResult(res));
+  return (req) =>
+    Promise.resolve(fetch(req)).then((res) => hooksFromFetchResult(res) as Partial<Hooks>);
 }
 
 /**
@@ -57,19 +58,32 @@ export function defaultResolve(server: Server, wsOpts: WSOptions): WSOptions["re
  * - a plain `{ crossws, headers }` object, where `headers` are applied to the
  *   WebSocket handshake response.
  */
-function hooksFromFetchResult(res: unknown): Partial<Hooks> {
+function hooksFromFetchResult(res: unknown): Partial<Hooks> | undefined {
   const crossws = (res as { crossws?: Partial<Hooks> } | undefined)?.crossws;
 
   if (res instanceof Response) {
-    // Only `.crossws` is consumed; release the rest of the response so a
-    // streaming/proxied body on the upgrade path isn't leaked per connection.
+    if (crossws) {
+      // Hooks attached — upgrade with them; the response body is unused, so
+      // release it (avoids leaking a streaming/proxied body per connection).
+      res.body?.cancel().catch(() => {});
+      return crossws;
+    }
+    // No hooks attached. Render an error/redirect response (send it to the
+    // client and fail the handshake) instead of silently upgrading a
+    // handler-less socket — e.g. an app returning
+    // `new Response("Unauthorized", { status: 401 })` on the upgrade path.
+    if (!res.ok) {
+      return { upgrade: () => res };
+    }
+    // A plain 2xx response without hooks: the app didn't opt into WebSockets for
+    // this request; upgrade with no hooks and release the body.
     res.body?.cancel().catch(() => {});
-    return crossws as Partial<Hooks>;
+    return undefined;
   }
 
   const headers = (res as { headers?: HeadersInit } | undefined)?.headers;
   if (!headers) {
-    return crossws as Partial<Hooks>;
+    return crossws;
   }
 
   // Apply the shortcut `headers` to the handshake by composing an `upgrade`

--- a/src/server/_resolve.ts
+++ b/src/server/_resolve.ts
@@ -44,12 +44,56 @@ export function defaultResolve(server: Server, wsOpts: WSOptions): WSOptions["re
     throw new Error("[crossws] server has no fetch handler to resolve WebSocket hooks from");
   }
 
-  return (req) =>
-    Promise.resolve(fetch(req)).then((res) => {
-      const hooks = (res as { crossws?: Partial<Hooks> }).crossws;
-      // Only `.crossws` is consumed; release the rest of the response so a
-      // streaming/proxied body on the upgrade path isn't leaked per connection.
-      res.body?.cancel().catch(() => {});
-      return hooks as Partial<Hooks>;
-    });
+  return (req) => Promise.resolve(fetch(req)).then((res) => hooksFromFetchResult(res));
+}
+
+/**
+ * Extract WebSocket hooks from a `fetch` result for the default resolver.
+ *
+ * The result may be either:
+ * - a `Response` carrying hooks on its `crossws` property — only `.crossws` is
+ *   read, the body is released, and the response's HTTP headers are ignored
+ *   (they are not handshake headers); or
+ * - a plain `{ crossws, headers }` object, where `headers` are applied to the
+ *   WebSocket handshake response.
+ */
+function hooksFromFetchResult(res: unknown): Partial<Hooks> {
+  const crossws = (res as { crossws?: Partial<Hooks> } | undefined)?.crossws;
+
+  if (res instanceof Response) {
+    // Only `.crossws` is consumed; release the rest of the response so a
+    // streaming/proxied body on the upgrade path isn't leaked per connection.
+    res.body?.cancel().catch(() => {});
+    return crossws as Partial<Hooks>;
+  }
+
+  const headers = (res as { headers?: HeadersInit } | undefined)?.headers;
+  if (!headers) {
+    return crossws as Partial<Hooks>;
+  }
+
+  // Apply the shortcut `headers` to the handshake by composing an `upgrade`
+  // hook, merged with (and overridden by) any `upgrade` hook from `.crossws`.
+  const userUpgrade = crossws?.upgrade;
+  return {
+    ...crossws,
+    async upgrade(request) {
+      const result = await userUpgrade?.(request);
+      if (result instanceof Response) {
+        return result;
+      }
+      return { ...result, headers: mergeHeaders(headers, result?.headers) };
+    },
+  };
+}
+
+function mergeHeaders(base: HeadersInit, extra?: HeadersInit): HeadersInit {
+  if (!extra) {
+    return base;
+  }
+  const merged = new Headers(base);
+  for (const [key, value] of new Headers(extra)) {
+    merged.set(key, value);
+  }
+  return merged;
 }

--- a/src/server/_resolve.ts
+++ b/src/server/_resolve.ts
@@ -3,7 +3,16 @@ import type { Server } from "srvx";
 import type { Hooks } from "../hooks";
 import type { WSOptions } from "./_types";
 
-const HOOK_NAMES: (keyof Hooks)[] = ["upgrade", "message", "open", "close", "drain", "error"];
+const HOOK_NAMES = ["upgrade", "message", "open", "close", "drain", "error"] as const;
+
+// Compile-time guard: if a hook is added to `Hooks` but not listed above, the
+// leftover key is no longer `never`, so this type resolves to a tuple and the
+// `satisfies true` below errors — preventing the inline-hook detection in
+// `defaultResolve` from silently missing the new hook.
+type _AllHookNamesListed = [Exclude<keyof Hooks, (typeof HOOK_NAMES)[number]>] extends [never]
+  ? true
+  : ["HOOK_NAMES is missing hook(s):", Exclude<keyof Hooks, (typeof HOOK_NAMES)[number]>];
+true satisfies _AllHookNamesListed;
 
 /**
  * Resolve the hooks resolver for a server plugin.
@@ -36,7 +45,11 @@ export function defaultResolve(server: Server, wsOpts: WSOptions): WSOptions["re
   }
 
   return (req) =>
-    Promise.resolve(fetch(req)).then(
-      (res) => (res as { crossws?: Partial<Hooks> }).crossws as Partial<Hooks>,
-    );
+    Promise.resolve(fetch(req)).then((res) => {
+      const hooks = (res as { crossws?: Partial<Hooks> }).crossws;
+      // Only `.crossws` is consumed; release the rest of the response so a
+      // streaming/proxied body on the upgrade path isn't leaked per connection.
+      res.body?.cancel().catch(() => {});
+      return hooks as Partial<Hooks>;
+    });
 }

--- a/src/server/_resolve.ts
+++ b/src/server/_resolve.ts
@@ -1,0 +1,42 @@
+import type { Server } from "srvx";
+
+import type { Hooks } from "../hooks";
+import type { WSOptions } from "./_types";
+
+const HOOK_NAMES: (keyof Hooks)[] = ["upgrade", "message", "open", "close", "drain", "error"];
+
+/**
+ * Resolve the hooks resolver for a server plugin.
+ *
+ * - When the user provides an explicit `resolve`, it is returned unchanged.
+ * - When the user passes inline hook functions (e.g. `ws({ message })`) and no
+ *   `resolve`, `undefined` is returned so those hooks run via the adapter's
+ *   global-hook path with zero per-event overhead. Inline hooks and
+ *   app-resolved hooks are treated as mutually exclusive modes.
+ * - Otherwise a default resolver is returned that calls the server's own
+ *   `fetch` handler and reads the `crossws` property off the returned
+ *   `Response` (the srvx convention for attaching WebSocket hooks).
+ *
+ * @throws if the server has no `fetch` handler to resolve hooks from.
+ */
+export function defaultResolve(server: Server, wsOpts: WSOptions): WSOptions["resolve"] {
+  if (wsOpts.resolve) {
+    return wsOpts.resolve;
+  }
+
+  // Inline hooks are handled by the adapter's global-hook path; adding the
+  // default resolver would only cost an extra fetch per hook event.
+  if (HOOK_NAMES.some((name) => typeof wsOpts[name] === "function")) {
+    return undefined;
+  }
+
+  const fetch = server.options.fetch;
+  if (typeof fetch !== "function") {
+    throw new Error("[crossws] server has no fetch handler to resolve WebSocket hooks from");
+  }
+
+  return (req) =>
+    Promise.resolve(fetch(req)).then(
+      (res) => (res as { crossws?: Partial<Hooks> }).crossws as Partial<Hooks>,
+    );
+}

--- a/src/server/_types.ts
+++ b/src/server/_types.ts
@@ -1,6 +1,6 @@
 import type { Server, ServerPlugin, ServerOptions, ServerRequest } from "srvx";
 
-import type { Hooks } from "../hooks";
+import type { Hooks, MaybePromise } from "../hooks";
 
 import type { BunOptions } from "../adapters/bun";
 import type { BunnyOptions } from "../adapters/bunny";
@@ -30,7 +30,25 @@ export type WSOptions = Partial<Hooks> & {
   };
 };
 
-export type ServerWithWSOptions = ServerOptions & { websocket?: WSOptions };
+/**
+ * Value the app `fetch` handler may return for a WebSocket upgrade request when
+ * the default resolver is used. Either:
+ * - a `Response` carrying hooks on its `crossws` property (the srvx convention),
+ *   or
+ * - a plain `{ crossws, headers }` object with the hooks and optional headers to
+ *   send on the WebSocket handshake response.
+ *
+ * Returning a normal `Response` (no `crossws`) is always valid — the connection
+ * simply upgrades without hooks.
+ */
+export type WSUpgradeResult =
+  | (Response & { crossws?: Partial<Hooks> })
+  | { crossws?: Partial<Hooks>; headers?: HeadersInit };
+
+export type ServerWithWSOptions = Omit<ServerOptions, "fetch"> & {
+  fetch: (request: ServerRequest) => MaybePromise<WSUpgradeResult>;
+  websocket?: WSOptions;
+};
 
 export declare function plugin(options: WSOptions): ServerPlugin;
 

--- a/src/server/_types.ts
+++ b/src/server/_types.ts
@@ -10,6 +10,15 @@ import type { SSEOptions } from "../adapters/sse";
 import type { CloudflareOptions } from "../adapters/cloudflare";
 
 export type WSOptions = Partial<Hooks> & {
+  /**
+   * Resolve the WebSocket hooks for an incoming request.
+   *
+   * When omitted, hooks are resolved by calling the server's `fetch` handler
+   * and reading the `crossws` property off the returned `Response`. Provide
+   * `resolve` only to customize routing (e.g. resolve hooks without invoking
+   * the app). The default is skipped when inline hooks are passed directly
+   * (e.g. `ws({ message })`), which run with zero per-event overhead instead.
+   */
   resolve?: (req: ServerRequest) => Partial<Hooks> | Promise<Partial<Hooks>>;
   options?: {
     bun?: BunOptions;

--- a/src/server/bun.ts
+++ b/src/server/bun.ts
@@ -1,5 +1,6 @@
 import { serve as srvxServe } from "srvx/bun";
 import adapter from "../adapters/bun";
+import { defaultResolve } from "./_resolve";
 
 import type { Server, ServerPlugin } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
@@ -8,7 +9,7 @@ export function plugin(wsOpts: WSOptions): ServerPlugin {
   return (server) => {
     const ws = adapter({
       hooks: wsOpts,
-      resolve: wsOpts.resolve,
+      resolve: defaultResolve(server, wsOpts),
       ...wsOpts.options?.bun,
     });
 

--- a/src/server/bun.ts
+++ b/src/server/bun.ts
@@ -2,7 +2,7 @@ import { serve as srvxServe } from "srvx/bun";
 import adapter from "../adapters/bun";
 import { defaultResolve } from "./_resolve";
 
-import type { Server, ServerPlugin } from "srvx";
+import type { Server, ServerPlugin, ServerOptions } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
 
 export function plugin(wsOpts: WSOptions): ServerPlugin {
@@ -33,5 +33,5 @@ export function serve(options: ServerWithWSOptions): Server {
     options.plugins ||= [];
     options.plugins.push(plugin(options.websocket));
   }
-  return srvxServe(options);
+  return srvxServe(options as ServerOptions);
 }

--- a/src/server/bunny.ts
+++ b/src/server/bunny.ts
@@ -2,7 +2,7 @@ import { serve as srvxServe } from "srvx/bunny";
 import adapter from "../adapters/bunny";
 import { defaultResolve } from "./_resolve";
 
-import type { Server, ServerPlugin } from "srvx";
+import type { Server, ServerPlugin, ServerOptions } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
 
 export function plugin(wsOpts: WSOptions): ServerPlugin {
@@ -27,5 +27,5 @@ export function serve(options: ServerWithWSOptions): Server {
     options.plugins ||= [];
     options.plugins.push(plugin(options.websocket));
   }
-  return srvxServe(options);
+  return srvxServe(options as ServerOptions);
 }

--- a/src/server/bunny.ts
+++ b/src/server/bunny.ts
@@ -1,5 +1,6 @@
 import { serve as srvxServe } from "srvx/bunny";
 import adapter from "../adapters/bunny";
+import { defaultResolve } from "./_resolve";
 
 import type { Server, ServerPlugin } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
@@ -8,7 +9,7 @@ export function plugin(wsOpts: WSOptions): ServerPlugin {
   return (server) => {
     const ws = adapter({
       hooks: wsOpts,
-      resolve: wsOpts.resolve,
+      resolve: defaultResolve(server, wsOpts),
       ...wsOpts.options?.bunny,
     });
 

--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -2,7 +2,7 @@ import { serve as srvxServe } from "srvx/cloudflare";
 import adapter from "../adapters/cloudflare";
 import { defaultResolve } from "./_resolve";
 
-import type { Server, ServerPlugin } from "srvx";
+import type { Server, ServerPlugin, ServerOptions } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
 
 export function plugin(wsOpts: WSOptions): ServerPlugin {
@@ -30,5 +30,5 @@ export function serve(options: ServerWithWSOptions): Server {
     options.plugins ||= [];
     options.plugins.push(plugin(options.websocket));
   }
-  return srvxServe(options) as unknown as Server; // cloudflare fetch types are incompatible...
+  return srvxServe(options as ServerOptions) as unknown as Server; // cloudflare fetch types are incompatible...
 }

--- a/src/server/cloudflare.ts
+++ b/src/server/cloudflare.ts
@@ -1,5 +1,6 @@
 import { serve as srvxServe } from "srvx/cloudflare";
 import adapter from "../adapters/cloudflare";
+import { defaultResolve } from "./_resolve";
 
 import type { Server, ServerPlugin } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
@@ -8,7 +9,7 @@ export function plugin(wsOpts: WSOptions): ServerPlugin {
   return (server) => {
     const ws = adapter({
       hooks: wsOpts,
-      resolve: wsOpts.resolve,
+      resolve: defaultResolve(server, wsOpts),
       ...wsOpts.options?.cloudflare,
     });
     server.options.middleware.unshift((req, next) => {

--- a/src/server/default.ts
+++ b/src/server/default.ts
@@ -1,19 +1,20 @@
 import { serve as srvxServe } from "srvx";
 import adapter from "../adapters/sse";
+import { defaultResolve } from "./_resolve";
 
 import type { Server, ServerPlugin } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
 
 export function plugin(wsOpts: WSOptions): ServerPlugin {
-  const ws = adapter({
-    hooks: wsOpts,
-    resolve: wsOpts.resolve,
-    ...wsOpts.options?.sse,
-  });
   console.warn(
     "[crossws] Using SSE adapter for WebSocket support. This requires a custom WebSocket client (https://crossws.h3.dev/adapters/sse).",
   );
   return (server) => {
+    const ws = adapter({
+      hooks: wsOpts,
+      resolve: defaultResolve(server, wsOpts),
+      ...wsOpts.options?.sse,
+    });
     server.options.middleware.unshift((req, next) => {
       if (req.headers.get("upgrade")?.toLowerCase() === "websocket") {
         return ws.fetch(req);

--- a/src/server/default.ts
+++ b/src/server/default.ts
@@ -2,7 +2,7 @@ import { serve as srvxServe } from "srvx";
 import adapter from "../adapters/sse";
 import { defaultResolve } from "./_resolve";
 
-import type { Server, ServerPlugin } from "srvx";
+import type { Server, ServerPlugin, ServerOptions } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
 
 export function plugin(wsOpts: WSOptions): ServerPlugin {
@@ -29,5 +29,5 @@ export function serve(options: ServerWithWSOptions): Server {
     options.plugins ||= [];
     options.plugins.push(plugin(options.websocket));
   }
-  return srvxServe(options);
+  return srvxServe(options as ServerOptions);
 }

--- a/src/server/deno.ts
+++ b/src/server/deno.ts
@@ -2,7 +2,7 @@ import { serve as srvxServe } from "srvx/deno";
 import adapter from "../adapters/deno";
 import { defaultResolve } from "./_resolve";
 
-import type { Server, ServerPlugin } from "srvx";
+import type { Server, ServerPlugin, ServerOptions } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
 
 export function plugin(wsOpts: WSOptions): ServerPlugin {
@@ -27,5 +27,5 @@ export function serve(options: ServerWithWSOptions): Server {
     options.plugins ||= [];
     options.plugins.push(plugin(options.websocket));
   }
-  return srvxServe(options);
+  return srvxServe(options as ServerOptions);
 }

--- a/src/server/deno.ts
+++ b/src/server/deno.ts
@@ -1,5 +1,6 @@
 import { serve as srvxServe } from "srvx/deno";
 import adapter from "../adapters/deno";
+import { defaultResolve } from "./_resolve";
 
 import type { Server, ServerPlugin } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
@@ -8,7 +9,7 @@ export function plugin(wsOpts: WSOptions): ServerPlugin {
   return (server) => {
     const ws = adapter({
       hooks: wsOpts,
-      resolve: wsOpts.resolve,
+      resolve: defaultResolve(server, wsOpts),
       ...wsOpts.options?.deno,
     });
 

--- a/src/server/node.ts
+++ b/src/server/node.ts
@@ -2,7 +2,7 @@ import { serve as srvxServe, NodeRequest } from "srvx/node";
 import adapter from "../adapters/node";
 import { defaultResolve } from "./_resolve";
 
-import type { Server, ServerPlugin } from "srvx";
+import type { Server, ServerPlugin, ServerOptions } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
 
 export function plugin(wsOpts: WSOptions): ServerPlugin {
@@ -33,5 +33,5 @@ export function serve(options: ServerWithWSOptions): Server {
     options.plugins ||= [];
     options.plugins.push(plugin(options.websocket));
   }
-  return srvxServe(options);
+  return srvxServe(options as ServerOptions);
 }

--- a/src/server/node.ts
+++ b/src/server/node.ts
@@ -1,5 +1,6 @@
 import { serve as srvxServe, NodeRequest } from "srvx/node";
 import adapter from "../adapters/node";
+import { defaultResolve } from "./_resolve";
 
 import type { Server, ServerPlugin } from "srvx";
 import type { WSOptions, ServerWithWSOptions } from "./_types";
@@ -8,8 +9,8 @@ export function plugin(wsOpts: WSOptions): ServerPlugin {
   return (server) => {
     const ws = adapter({
       hooks: wsOpts,
-      resolve: wsOpts.resolve,
-      ...wsOpts.options?.deno,
+      resolve: defaultResolve(server, wsOpts),
+      ...wsOpts.options?.node,
     });
     const originalServe = server.serve;
     server.serve = () => {

--- a/test/server-resolve.test.ts
+++ b/test/server-resolve.test.ts
@@ -154,6 +154,58 @@ test("inline global hooks still work without a resolve or fetch .crossws", async
   await once(client, "close");
 });
 
+test("app fetch may return a plain { crossws } object (no Response instance)", async () => {
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => ({
+      crossws: {
+        message(peer, message) {
+          peer.send(`echo:${message.text()}`);
+        },
+      },
+    }),
+    websocket: {}, // default resolver reads `.crossws` off the returned object
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  await once(client, "open");
+  client.send("hi");
+  const [reply] = await once(client, "message");
+  expect(reply.toString()).toBe("echo:hi");
+  client.close();
+  await once(client, "close");
+});
+
+test("app fetch may return { crossws, headers } to set handshake headers", async () => {
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => ({
+      crossws: {
+        message(peer, message) {
+          peer.send(message.text());
+        },
+      },
+      headers: { "x-hello": "world" },
+    }),
+    websocket: {},
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  // `ws` emits `upgrade` with the raw handshake response (an IncomingMessage).
+  const [res] = (await once(client, "upgrade")) as [{ headers: Record<string, string> }];
+  expect(res.headers["x-hello"]).toBe("world");
+  client.close();
+  await once(client, "close");
+});
+
 test("defaultResolve returns the explicit resolve unchanged", () => {
   const resolve: WSOptions["resolve"] = () => ({});
   const server = { options: { fetch: () => new Response("ok") } } as unknown as Server;

--- a/test/server-resolve.test.ts
+++ b/test/server-resolve.test.ts
@@ -363,6 +363,25 @@ test("cross-provider: default fetch resolver is not invoked per message", async 
   await once(client, "close");
 });
 
+test("a non-ok app fetch Response is rendered (upgrade rejected)", async () => {
+  // An app returning e.g. `new Response("Unauthorized", { status: 401 })` on the
+  // upgrade path must fail the handshake and send that response, not silently
+  // open a handler-less socket.
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => new Response("Unauthorized", { status: 401 }),
+    websocket: {}, // default resolver
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  const [error] = await once(client, "error");
+  expect((error as Error).message).toContain("401");
+});
+
 test("a synchronously throwing app fetch fails the handshake cleanly", async () => {
   // The default resolver calls the app `fetch` on upgrade. A fetch that throws
   // *synchronously* must not escape as an uncaught exception nor hang the

--- a/test/server-resolve.test.ts
+++ b/test/server-resolve.test.ts
@@ -7,7 +7,7 @@ import { defaultResolve } from "../src/server/_resolve.ts";
 import { AdapterHookable } from "../src/hooks.ts";
 import type { Server } from "srvx";
 import type { Hooks } from "../src/hooks.ts";
-import type { Peer } from "../src/peer.ts";
+import type { Peer, PeerContext } from "../src/peer.ts";
 import type { Message } from "../src/message.ts";
 import type { WSOptions } from "../src/server/_types.ts";
 
@@ -214,6 +214,41 @@ test("cross-provider: resolve runs once per connection, not per message", async 
   expect(resolveCalls).toBe(2);
 });
 
+test("cross-provider: upgrade + peer events share a single resolve via context", async () => {
+  // Real adapters give the peer a *different* `request` object than the upgrade
+  // request (e.g. deno snapshots it, node wraps a fresh proxy), so the upgrade
+  // event and later peer events would resolve twice if keyed by request. They
+  // are keyed by the shared `context` object instead — this asserts exactly one
+  // resolve spans the whole connection.
+  let resolveCalls = 0;
+  const hooks = new AdapterHookable({
+    resolve: () => {
+      resolveCalls++;
+      return { upgrade() {}, open() {}, message() {}, close() {} };
+    },
+  });
+  const msg = (text: string) => ({ text: () => text }) as unknown as Message;
+
+  // Upgrade seeds the cache against the returned `context`.
+  const upgradeReq = new Request("http://localhost/") as Request & { context?: PeerContext };
+  const { context } = await hooks.upgrade(upgradeReq);
+  expect(resolveCalls).toBe(1);
+
+  // Peer carries the SAME context but a DIFFERENT request object.
+  const peer = {
+    request: new Request("http://localhost/snapshot"),
+    context,
+  } as unknown as Peer;
+  await hooks.callHook("open", peer);
+  for (let i = 0; i < 10; i++) {
+    await hooks.callHook("message", peer, msg(`m${i}`));
+  }
+  await hooks.callHook("close", peer, {});
+
+  // Still one — the upgrade's resolve was reused for every peer event.
+  expect(resolveCalls).toBe(1);
+});
+
 test("cross-provider: default fetch resolver is not invoked per message", async () => {
   let fetchCalls = 0;
   const port = await getRandomPort("localhost");
@@ -236,17 +271,15 @@ test("cross-provider: default fetch resolver is not invoked per message", async 
   const client = new WebSocket(`ws://127.0.0.1:${port}/`);
   await once(client, "open");
 
-  // Drive one message so the connection is fully resolved, then snapshot.
-  client.send("m0");
-  await once(client, "message");
-  const callsAfterFirst = fetchCalls;
-
-  // Many more messages must NOT trigger further fetch/resolve calls.
-  for (let i = 1; i <= 20; i++) {
+  // Drive many messages — none must trigger an additional fetch/resolve.
+  for (let i = 0; i <= 20; i++) {
     client.send(`m${i}`);
     await once(client, "message");
   }
-  expect(fetchCalls).toBe(callsAfterFirst);
+
+  // Exactly one fetch served the whole connection (the upgrade resolve, reused
+  // for open + every message via the shared `context` key).
+  expect(fetchCalls).toBe(1);
 
   client.close();
   await once(client, "close");

--- a/test/server-resolve.test.ts
+++ b/test/server-resolve.test.ts
@@ -4,8 +4,11 @@ import { afterEach, beforeEach, expect, test } from "vitest";
 import WebSocket from "ws";
 import { serve } from "../src/server/node.ts";
 import { defaultResolve } from "../src/server/_resolve.ts";
+import { AdapterHookable } from "../src/hooks.ts";
 import type { Server } from "srvx";
 import type { Hooks } from "../src/hooks.ts";
+import type { Peer } from "../src/peer.ts";
+import type { Message } from "../src/message.ts";
 import type { WSOptions } from "../src/server/_types.ts";
 
 type ServeReturn = ReturnType<typeof serve>;
@@ -171,6 +174,82 @@ test("defaultResolve reads .crossws off the fetch Response", async () => {
   expect(typeof resolve).toBe("function");
   const req = new Request("http://localhost/");
   await expect(resolve!(req as never)).resolves.toBe(hooks);
+});
+
+// `AdapterHookable.callHook` is the single code path EVERY runtime adapter
+// (node/bun/deno/cloudflare/bunny/sse/uws) funnels its events through, so a
+// resolver-invocation count asserted here holds for all providers. This is the
+// core guarantee: `resolve` must not run per message.
+test("cross-provider: resolve runs once per connection, not per message", async () => {
+  let resolveCalls = 0;
+  const hooks = new AdapterHookable({
+    resolve: () => {
+      resolveCalls++;
+      return {
+        open() {},
+        message() {},
+        close() {},
+      };
+    },
+  });
+
+  // One connection = one stable `peer.request` identity, reused across events.
+  const request = new Request("http://localhost/");
+  const peer = { request } as unknown as Peer;
+  const msg = (text: string) => ({ text: () => text }) as unknown as Message;
+
+  await hooks.callHook("open", peer);
+  for (let i = 0; i < 20; i++) {
+    await hooks.callHook("message", peer, msg(`m${i}`));
+  }
+  await hooks.callHook("close", peer, {});
+
+  // 20 messages + open + close = 22 events, but resolve ran only once.
+  expect(resolveCalls).toBe(1);
+
+  // A second, distinct connection resolves independently (once).
+  const peer2 = { request: new Request("http://localhost/other") } as unknown as Peer;
+  await hooks.callHook("open", peer2);
+  await hooks.callHook("message", peer2, msg("hi"));
+  expect(resolveCalls).toBe(2);
+});
+
+test("cross-provider: default fetch resolver is not invoked per message", async () => {
+  let fetchCalls = 0;
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: (req) => {
+      fetchCalls++;
+      return fetchWithCrossws({
+        message(peer, message) {
+          peer.send(`echo:${message.text()}`);
+        },
+      })(req);
+    },
+    websocket: {}, // default resolver
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  await once(client, "open");
+
+  // Drive one message so the connection is fully resolved, then snapshot.
+  client.send("m0");
+  await once(client, "message");
+  const callsAfterFirst = fetchCalls;
+
+  // Many more messages must NOT trigger further fetch/resolve calls.
+  for (let i = 1; i <= 20; i++) {
+    client.send(`m${i}`);
+    await once(client, "message");
+  }
+  expect(fetchCalls).toBe(callsAfterFirst);
+
+  client.close();
+  await once(client, "close");
 });
 
 test("defaultResolve throws a clear error when fetch is missing", () => {

--- a/test/server-resolve.test.ts
+++ b/test/server-resolve.test.ts
@@ -1,0 +1,181 @@
+import { once } from "node:events";
+import { getRandomPort } from "get-port-please";
+import { afterEach, beforeEach, expect, test } from "vitest";
+import WebSocket from "ws";
+import { serve } from "../src/server/node.ts";
+import { defaultResolve } from "../src/server/_resolve.ts";
+import type { Server } from "srvx";
+import type { Hooks } from "../src/hooks.ts";
+import type { WSOptions } from "../src/server/_types.ts";
+
+type ServeReturn = ReturnType<typeof serve>;
+
+let currentServer: ServeReturn | undefined;
+let unhandled: unknown[] = [];
+
+function onUnhandled(err: unknown) {
+  unhandled.push(err);
+}
+
+beforeEach(() => {
+  unhandled = [];
+  process.on("unhandledRejection", onUnhandled);
+  process.on("uncaughtException", onUnhandled);
+});
+
+afterEach(async () => {
+  process.off("unhandledRejection", onUnhandled);
+  process.off("uncaughtException", onUnhandled);
+  await currentServer?.close(true);
+  currentServer = undefined;
+  await new Promise((r) => setImmediate(r));
+  if (unhandled.length > 0) {
+    throw new AggregateError(
+      unhandled as Error[],
+      `Unexpected unhandled errors during test: ${unhandled
+        .map((e) => (e as Error)?.message ?? String(e))
+        .join("; ")}`,
+    );
+  }
+});
+
+// A fetch handler that mirrors the srvx/h3 convention: WebSocket hooks are
+// attached to the returned Response as a non-standard `.crossws` property.
+function fetchWithCrossws(hooks: Partial<Hooks>): (req: Request) => Response {
+  return () => {
+    const res = new Response("ok");
+    (res as { crossws?: Partial<Hooks> }).crossws = hooks;
+    return res;
+  };
+}
+
+test("no resolve: hooks are resolved from the fetch handler's .crossws", async () => {
+  const events: string[] = [];
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: fetchWithCrossws({
+      open() {
+        events.push("open");
+      },
+      message(peer, message) {
+        events.push(`message:${message.text()}`);
+        peer.send(`echo:${message.text()}`);
+      },
+      close() {
+        events.push("close");
+      },
+    }),
+    websocket: {}, // <-- no resolve, no inline hooks
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  await once(client, "open");
+  client.send("hello");
+  const [reply] = await once(client, "message");
+  expect(reply.toString()).toBe("echo:hello");
+  client.close();
+  await once(client, "close");
+  // Give the close hook a tick to fire.
+  await new Promise((r) => setTimeout(r, 50));
+
+  expect(events).toContain("open");
+  expect(events).toContain("message:hello");
+  expect(events).toContain("close");
+});
+
+test("explicit resolve takes precedence over the app fetch default", async () => {
+  const events: string[] = [];
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    // The app fetch attaches hooks that must NOT be used when resolve is given.
+    fetch: fetchWithCrossws({
+      message(peer) {
+        peer.send("from-app-fetch");
+      },
+    }),
+    websocket: {
+      resolve: () => ({
+        message(peer, message) {
+          events.push(`resolved:${message.text()}`);
+          peer.send(`resolved:${message.text()}`);
+        },
+      }),
+    },
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  await once(client, "open");
+  client.send("hi");
+  const [reply] = await once(client, "message");
+  expect(reply.toString()).toBe("resolved:hi");
+  expect(events).toEqual(["resolved:hi"]);
+  client.close();
+  await once(client, "close");
+});
+
+test("inline global hooks still work without a resolve or fetch .crossws", async () => {
+  const events: string[] = [];
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    // App fetch does NOT attach .crossws — inline hooks must handle everything.
+    fetch: () => new Response("ok"),
+    websocket: {
+      open() {
+        events.push("open");
+      },
+      message(peer, message) {
+        peer.send(`inline:${message.text()}`);
+      },
+    },
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  await once(client, "open");
+  client.send("yo");
+  const [reply] = await once(client, "message");
+  expect(reply.toString()).toBe("inline:yo");
+  expect(events).toContain("open");
+  client.close();
+  await once(client, "close");
+});
+
+test("defaultResolve returns the explicit resolve unchanged", () => {
+  const resolve: WSOptions["resolve"] = () => ({});
+  const server = { options: { fetch: () => new Response("ok") } } as unknown as Server;
+  expect(defaultResolve(server, { resolve })).toBe(resolve);
+});
+
+test("defaultResolve is skipped (undefined) when inline hooks are present", () => {
+  const server = { options: { fetch: () => new Response("ok") } } as unknown as Server;
+  expect(defaultResolve(server, { message() {} })).toBeUndefined();
+});
+
+test("defaultResolve reads .crossws off the fetch Response", async () => {
+  const hooks: Partial<Hooks> = { message() {} };
+  const server = {
+    options: { fetch: fetchWithCrossws(hooks) },
+  } as unknown as Server;
+  const resolve = defaultResolve(server, {});
+  expect(typeof resolve).toBe("function");
+  const req = new Request("http://localhost/");
+  await expect(resolve!(req as never)).resolves.toBe(hooks);
+});
+
+test("defaultResolve throws a clear error when fetch is missing", () => {
+  const server = { options: {} } as unknown as Server;
+  expect(() => defaultResolve(server, {})).toThrow(
+    "[crossws] server has no fetch handler to resolve WebSocket hooks from",
+  );
+});

--- a/test/server-resolve.test.ts
+++ b/test/server-resolve.test.ts
@@ -249,6 +249,32 @@ test("cross-provider: upgrade + peer events share a single resolve via context",
   expect(resolveCalls).toBe(1);
 });
 
+test("cross-provider: a rejected resolve is evicted so later events recover", async () => {
+  // A transient `resolve` failure (e.g. the default resolver's `fetch` throwing
+  // once) must not poison the whole connection — the cached rejection is evicted
+  // so the next event retries.
+  let calls = 0;
+  const hooks = new AdapterHookable({
+    resolve: () => {
+      calls++;
+      return calls === 1
+        ? Promise.reject(new Error("transient"))
+        : Promise.resolve({ message() {} });
+    },
+  });
+  const peer = {
+    request: new Request("http://localhost/"),
+    context: {} as PeerContext,
+  } as unknown as Peer;
+  const msg = (text: string) => ({ text: () => text }) as unknown as Message;
+
+  // First event: resolve rejects → this event rejects.
+  await expect(hooks.callHook("message", peer, msg("a"))).rejects.toThrow("transient");
+  // The failed cache entry is evicted, so the next event resolves afresh.
+  await expect(hooks.callHook("message", peer, msg("b"))).resolves.toBeUndefined();
+  expect(calls).toBe(2);
+});
+
 test("cross-provider: default fetch resolver is not invoked per message", async () => {
   let fetchCalls = 0;
   const port = await getRandomPort("localhost");

--- a/test/server-resolve.test.ts
+++ b/test/server-resolve.test.ts
@@ -311,6 +311,44 @@ test("cross-provider: default fetch resolver is not invoked per message", async 
   await once(client, "close");
 });
 
+test("a synchronously throwing app fetch fails the handshake cleanly", async () => {
+  // The default resolver calls the app `fetch` on upgrade. A fetch that throws
+  // *synchronously* must not escape as an uncaught exception nor hang the
+  // socket — the handshake should fail and the server stay up. (afterEach
+  // asserts no unhandledRejection/uncaughtException leaked.)
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => {
+      throw new Error("boom");
+    },
+    websocket: {}, // default resolver → calls app fetch on upgrade
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  const [error] = await once(client, "error");
+  expect(error).toBeInstanceOf(Error);
+});
+
+test("a rejecting app fetch fails the handshake cleanly", async () => {
+  const port = await getRandomPort("localhost");
+  const server = serve({
+    port,
+    hostname: "127.0.0.1",
+    fetch: () => Promise.reject(new Error("boom")),
+    websocket: {}, // default resolver → calls app fetch on upgrade
+  });
+  currentServer = server;
+  await server.ready();
+
+  const client = new WebSocket(`ws://127.0.0.1:${port}/`);
+  const [error] = await once(client, "error");
+  expect(error).toBeInstanceOf(Error);
+});
+
 test("defaultResolve throws a clear error when fetch is missing", () => {
   const server = { options: {} } as unknown as Server;
   expect(() => defaultResolve(server, {})).toThrow(


### PR DESCRIPTION
## Summary

Makes `resolve` **optional** for the `crossws/server` plugin, and makes hook resolution run **exactly once per connection**.

Every srvx/h3 user currently hand-writes the same `resolve` boilerplate to wire crossws back into their own app:

```js
// before
serve(app, {
  plugins: [ws({ resolve: async (req) => (await app.fetch(req)).crossws })],
});
```

After this change the common case is just:

```js
// after
serve(app, { plugins: [ws()] }); // no resolve
```

When `resolve` is omitted, hooks are resolved by calling the srvx server's own `fetch` handler and reading the `.crossws` property off the returned `Response` — the srvx-level convention for attaching WebSocket hooks. The plugin already has `server.options.fetch`, so it can do this itself.

## 1. Default `resolve` (`src/server/`)

- **New `src/server/_resolve.ts`** — shared `defaultResolve(server, wsOpts)` helper:
  - Returns an explicit `resolve` unchanged when provided.
  - Returns `undefined` when inline hooks (`ws({ message })`) are present, so those keep running via the adapter's global-hook path with **zero per-event overhead** (inline and app-resolved modes are mutually exclusive — decision point 1 in the task).
  - Otherwise returns a resolver that reads `.crossws` off the app's fetch `Response`.
  - Throws a clear error when the server has no `fetch` handler: `[crossws] server has no fetch handler to resolve WebSocket hooks from`.
- **`bun.ts`, `deno.ts`, `cloudflare.ts`, `node.ts`, `bunny.ts`** — swap `resolve: wsOpts.resolve` → `resolve: defaultResolve(server, wsOpts)`.
- **`default.ts` (SSE)** — refactored so the adapter is built **inside** the `(server) => {}` closure (needed to reach `server.options.fetch`); SSE `console.warn` preserved.
- **`_types.ts`** — updated `WSOptions.resolve` JSDoc to document the new default.
- **Drive-by fix**: `node.ts` was spreading `wsOpts.options?.deno` instead of `wsOpts.options?.node`.

## 2. Resolve exactly once per connection (`src/hooks.ts`)

`AdapterHookable.callHook` previously invoked `options.resolve(request)` on **every** hook event. Since every adapter routes `message`/`open`/`close`/`drain`/`error` through `callHook`, the default resolver's `fetch(req)` was firing **on every message**.

Now the resolved hooks are memoized in a `WeakMap` keyed by the connection's **`context` object** — which `upgrade()` creates (`request.context || {}`) and every adapter re-exposes verbatim as `peer.context`. That single shared identity spans both the `upgrade` event and every later peer event, so **one `resolve` call serves the whole connection** (the earlier approach keyed by `request` resolved twice, because adapters give the peer a different request object than the upgrade request). Keyed weakly, so entries are freed when the connection is GC'd.

This also addresses the per-event cost noted as out-of-scope (decision point 2) in the task.

## Tests (`test/server-resolve.test.ts`)

End-to-end via the node server + `ws` client, plus unit tests on the shared `AdapterHookable.callHook` path (the single choke point every provider funnels through, so the guarantee holds cross-provider):

- No `resolve` → hooks resolved from the fetch handler's `.crossws` (open/message/close fire).
- Explicit `resolve` still takes precedence.
- Inline global hooks still work without a `resolve` or fetch `.crossws`.
- Missing `server.options.fetch` throws the guard error.
- **`resolve` runs once per connection, not per message** (20 messages + open + close ⇒ one resolve; a second connection ⇒ two).
- **`upgrade` + peer events share a single resolve via `context`** (peer's `request` deliberately differs from the upgrade request).
- **End-to-end: exactly one `fetch` serves a whole connection** across 21 messages.

Each per-connection test was confirmed to **fail** on the pre-fix code path and pass after — locking in the guarantee. Full suite: **230 passed / 6 skipped**. `lint` + `typecheck` clean.

## Docs

Added a "Server plugin" section to the resolver guide (`docs/1.guide/7.resolver.md`) documenting `ws()` with no `resolve`, `resolve` as optional/custom-only, and that resolution is cached per connection.

## Notes / follow-ups (out of scope)

- The per-connection guarantee holds for in-memory adapters. Cloudflare Durable Objects with hibernation (a separate adapter, not the srvx `crossws/server` default path) reconstruct context on wake, so a woken peer resolves again — the in-memory `WeakMap` can't survive hibernation regardless.
- Coordinate the h3 side (`feat/ez-ws`) docs/examples and `crossws` peer-range bump once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebSocket hook resolution now defaults to deriving hooks from the server’s `fetch` response using `crossws` when no custom resolver is provided.
  * Adapter behavior now consistently uses this default resolver across supported server runtimes.

* **Bug Fixes**
  * Hook resolution is memoized per connection (runs once, not per message), supports explicit overrides, and evicts only failed resolution results for later retry.
  * WebSocket upgrade failures now fail the handshake cleanly with an HTTP 500 (avoids hanging/unhandled errors).

* **Documentation**
  * Updated Resolver API guide with a new “Server plugin” section and examples.

* **Tests**
  * Added/expanded integration and unit coverage for defaults, precedence, caching, retry semantics, and handshake error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->