### PR TITLE
feat: application-level ping/pong hooks and peer.ping()

### DIFF
--- a/docs/1.guide/2.hooks.md
+++ b/docs/1.guide/2.hooks.md
@@ -47,6 +47,18 @@ const hooks = defineHooks({
     // Pair with `peer.bufferedAmount`. Not all adapters emit this.
     console.log("[ws] drain", peer);
   },
+
+  ping(peer, data) {
+    // An application-level ping control frame arrived from the peer.
+    // Not all adapters emit this.
+    console.log("[ws] ping", peer, data);
+  },
+
+  pong(peer, data) {
+    // An application-level pong control frame arrived from the peer,
+    // typically in reply to `peer.ping()`. Not all adapters emit this.
+    console.log("[ws] pong", peer, data);
+  },
 });
 ```
 

--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -133,6 +133,34 @@ Abruptly close the connection.
 
 To gracefully close the connection, use `peer.close()`.
 
+### `peer.ping(data?)`
+
+Send an application-level WebSocket ping control frame to the client.
+
+Pair with the [`pong` hook](/guide/hooks) — e.g. embedding a timestamp in `data` — to measure round-trip latency:
+
+```ts
+import { defineHooks } from "crossws";
+
+const hooks = defineHooks({
+  message(peer, message) {
+    if (message.text() === "measure-latency") {
+      peer.context.pingSentAt = Date.now();
+      peer.ping();
+    }
+  },
+  pong(peer) {
+    const rtt = Date.now() - (peer.context.pingSentAt as number);
+    console.log(`[ws] round-trip latency: ${rtt}ms`);
+  },
+});
+```
+
+Use the [`ping` hook](/guide/hooks) to observe pings the client sends unprompted (e.g. a graphql-ws style client heartbeat).
+
+> [!NOTE]
+> Not all adapters can send a ping frame, or surface inbound ping/pong frames to the `ping`/`pong` hooks. Refer to the [compatibility table](#compatibility).
+
 ## Compatibility
 
 |                             | [Bun][bun] | [Cloudflare][cfw] | [Cloudflare (durable)][cfd] | [Deno][deno] | [Node (ws)][nodews] | [Node (μWebSockets)][nodeuws] | [SSE][sse] |
@@ -143,6 +171,8 @@ To gracefully close the connection, use `peer.close()`.
 | `terminate()`               | ✓          | ✓ [^2]            | ✓                           | ✓            | ✓                   | ✓                             | ✓ [^2]     |
 | `bufferedAmount`            | ✓          | ⨉ [^8]            | ⨉ [^8]                      | ✓            | ✓                   | ✓                             | ⨉ [^8]     |
 | `drain` hook                | ✓          | ⨉ [^9]            | ⨉ [^9]                      | ⨉ [^9]       | ✓                   | ✓                             | ⨉ [^9]     |
+| `ping()`                    | ✓          | ⨉ [^10]           | ⨉ [^10]                     | ⨉ [^10]      | ✓                   | ✓                             | ⨉ [^10]    |
+| `ping` / `pong` hooks       | ✓          | ⨉ [^10]           | ⨉ [^10]                     | ⨉ [^10]      | ✓                   | ✓                             | ⨉ [^10]    |
 | `request`                   | ✓          | ✓                 | ✓ [^30]                     | ✓            | ✓ [^31]             | ✓ [^31]                       | ✓          |
 | `remoteAddress`             | ✓          | ⨉                 | ⨉                           | ✓            | ✓                   | ✓                             | ⨉          |
 | `websocket.url`             | ✓          | ✓                 | ✓                           | ✓            | ✓                   | ✓                             | ✓          |
@@ -179,3 +209,5 @@ To gracefully close the connection, use `peer.close()`.
 [^8]: The runtime exposes no send-buffer signal, so `peer.bufferedAmount` reports `0`. (Cloudflare buffers and applies backpressure internally; SSE has no equivalent.)
 
 [^9]: The runtime emits no drain signal. Poll [`peer.bufferedAmount`](#peerbufferedamount) instead where it is available.
+
+[^10]: The runtime does not expose a ping/pong control-frame API to user code (pings/pongs are still handled transparently at the protocol level for liveness).

--- a/docs/1.guide/3.peer.md
+++ b/docs/1.guide/3.peer.md
@@ -137,7 +137,7 @@ To gracefully close the connection, use `peer.close()`.
 
 Send an application-level WebSocket ping control frame to the client.
 
-Pair with the [`pong` hook](/guide/hooks) — e.g. embedding a timestamp in `data` — to measure round-trip latency:
+Pair with the [`pong` hook](/guide/hooks) — embedding a correlatable payload (e.g. a timestamp) in `data` — to measure round-trip latency:
 
 ```ts
 import { defineHooks } from "crossws";
@@ -145,18 +145,24 @@ import { defineHooks } from "crossws";
 const hooks = defineHooks({
   message(peer, message) {
     if (message.text() === "measure-latency") {
-      peer.context.pingSentAt = Date.now();
-      peer.ping();
+      // Embed the send time in the ping payload; the client echoes it back
+      // in the pong so it can be told apart from keepalive pongs.
+      peer.ping(`rtt:${Date.now()}`);
     }
   },
-  pong(peer) {
-    const rtt = Date.now() - (peer.context.pingSentAt as number);
+  pong(peer, data) {
+    const payload = new TextDecoder().decode(data);
+    if (!payload.startsWith("rtt:")) return; // keepalive or unrelated pong
+    const rtt = Date.now() - Number(payload.slice(4));
     console.log(`[ws] round-trip latency: ${rtt}ms`);
   },
 });
 ```
 
 Use the [`ping` hook](/guide/hooks) to observe pings the client sends unprompted (e.g. a graphql-ws style client heartbeat).
+
+> [!NOTE]
+> The `pong` hook also fires for the pongs the client sends in reply to the adapter's own internal keepalive pings (see [`idleTimeout`](/adapters#idletimeout)), not only your `peer.ping()` calls. To measure RTT reliably, embed a correlatable payload in `peer.ping(data)` and ignore pongs that don't carry it (as above) rather than relying on a shared timestamp that any pong would consume.
 
 > [!NOTE]
 > Not all adapters can send a ping frame, or surface inbound ping/pong frames to the `ping`/`pong` hooks. Refer to the [compatibility table](#compatibility).

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -4,6 +4,7 @@ import { toBufferLike } from "../utils.ts";
 import { adapterUtils, getPeers, DEFAULT_IDLE_TIMEOUT } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
+import { WSError } from "../error.ts";
 import { Peer, type PeerContext } from "../peer.ts";
 import type { SyncDriver } from "../sync.ts";
 
@@ -65,36 +66,36 @@ const bunAdapter: Adapter<BunAdapter, BunOptions> = (options = {}) => {
       idleTimeout: options.idleTimeout ?? DEFAULT_IDLE_TIMEOUT,
       message: (ws, message) => {
         const peers = getPeers(globalPeers, ws.data.namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         hooks.callHook("message", peer, new Message(message, peer));
       },
       open: (ws) => {
         const peers = getPeers(globalPeers, ws.data.namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         peers.add(peer);
         hooks.callHook("open", peer);
       },
       close: (ws, code, reason) => {
         const peers = getPeers(globalPeers, ws.data.namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         peers.delete(peer);
         hooks.callHook("close", peer, { code, reason });
       },
       drain: (ws) => {
         const peers = getPeers(globalPeers, ws.data.namespace);
-        const peer = getPeer(ws, peers);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         hooks.callHook("drain", peer);
       },
       // Bun auto-replies to an inbound ping with a pong per the spec; these
       // hooks only observe the control frames, they don't need to answer them.
       ping: (ws, data) => {
         const peers = getPeers(globalPeers, ws.data.namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         hooks.callHook("ping", peer, data);
       },
       pong: (ws, data) => {
         const peers = getPeers(globalPeers, ws.data.namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         hooks.callHook("pong", peer, data);
       },
     },
@@ -108,7 +109,8 @@ export default bunAdapter;
 function getPeer(
   ws: ServerWebSocket<ContextData>,
   peers: Set<BunPeer>,
-  sync?: SyncDriver,
+  sync: SyncDriver | undefined,
+  hooks: AdapterHookable,
 ): BunPeer {
   if (ws.data.peer) {
     return ws.data.peer;
@@ -119,6 +121,7 @@ function getPeer(
     peers,
     namespace: ws.data.namespace,
     sync,
+    hooks,
   });
   ws.data.peer = peer;
   return peer;
@@ -130,6 +133,7 @@ class BunPeer extends Peer<{
   request: Request;
   peers: Set<BunPeer>;
   sync?: SyncDriver;
+  hooks: AdapterHookable;
 }> {
   override get remoteAddress(): string {
     return this._internal.ws.remoteAddress;
@@ -170,6 +174,14 @@ class BunPeer extends Peer<{
   }
 
   override ping(data?: unknown): number {
-    return this._internal.ws.ping(data as any);
+    // Guard against the native ping rejecting the payload (e.g. the 125-byte
+    // control-frame limit): surface it through the `error` hook rather than
+    // letting it crash a caller inside a hook handler.
+    try {
+      return this._internal.ws.ping(data as any);
+    } catch (error) {
+      this._internal.hooks.callHook("error", this, new WSError(error));
+      return 0;
+    }
   }
 }

--- a/src/adapters/bun.ts
+++ b/src/adapters/bun.ts
@@ -85,6 +85,18 @@ const bunAdapter: Adapter<BunAdapter, BunOptions> = (options = {}) => {
         const peer = getPeer(ws, peers);
         hooks.callHook("drain", peer);
       },
+      // Bun auto-replies to an inbound ping with a pong per the spec; these
+      // hooks only observe the control frames, they don't need to answer them.
+      ping: (ws, data) => {
+        const peers = getPeers(globalPeers, ws.data.namespace);
+        const peer = getPeer(ws, peers, baseUtils.sync);
+        hooks.callHook("ping", peer, data);
+      },
+      pong: (ws, data) => {
+        const peers = getPeers(globalPeers, ws.data.namespace);
+        const peer = getPeer(ws, peers, baseUtils.sync);
+        hooks.callHook("pong", peer, data);
+      },
     },
   };
 };
@@ -155,5 +167,9 @@ class BunPeer extends Peer<{
 
   override terminate(): void {
     this._internal.ws.terminate();
+  }
+
+  override ping(data?: unknown): number {
+    return this._internal.ws.ping(data as any);
   }
 }

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -25,6 +25,12 @@ type AugmentedReq = IncomingMessage & {
 // `ws` instance tagged with the heartbeat liveness flag (see the idle sweep below).
 type HeartbeatWS = WebSocketT & { _isAlive?: boolean };
 
+// Payload carried by our own liveness probe (see the idle sweep). The client
+// echoes it back in the pong, letting the `pong` handler tell an internal
+// keepalive reply apart from an app-level `peer.ping()` and skip the `pong`
+// hook for it. Kept well under the 125-byte control-frame limit.
+const HEARTBEAT_PING = Buffer.from("crossws-ping");
+
 export interface NodeAdapter extends AdapterInstance {
   handleUpgrade(
     req: IncomingMessage,
@@ -89,6 +95,7 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
       nodeReq,
       namespace: nodeReq._namespace,
       sync: baseUtils.sync,
+      hooks,
     });
     peers.add(peer);
     liveSockets.add(ws as HeartbeatWS);
@@ -122,6 +129,12 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
       hooks.callHook("ping", peer, data);
     });
     ws.on("pong", (data: Buffer) => {
+      // Skip our own liveness probe's echoed pong (see the idle sweep); it is
+      // not an app-level pong and would otherwise fire the `pong` hook every
+      // idle interval with a bogus payload.
+      if (data.equals(HEARTBEAT_PING)) {
+        return;
+      }
       hooks.callHook("pong", peer, data);
     });
     ws.on("error", (error: Error) => {
@@ -168,7 +181,7 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
         }
         ws._isAlive = false;
         try {
-          ws.ping();
+          ws.ping(HEARTBEAT_PING);
         } catch {
           // socket may have raced into CLOSING between the sweep and the ping
         }
@@ -253,6 +266,7 @@ class NodePeer extends Peer<{
   nodeReq: IncomingMessage;
   ws: WebSocketT & { _peer?: NodePeer };
   sync?: SyncDriver;
+  hooks: AdapterHookable;
 }> {
   override get remoteAddress() {
     return this._internal.nodeReq.socket?.remoteAddress;
@@ -300,7 +314,15 @@ class NodePeer extends Peer<{
   }
 
   override ping(data?: unknown): void {
-    this._internal.ws.ping(data);
+    // `ws` validates the control frame synchronously (rejecting non-buffer
+    // payloads and anything over the 125-byte limit) and throws. Surface that
+    // through the `error` hook instead of letting it crash the process — e.g.
+    // when `ping()` is called from inside a hook handler.
+    try {
+      this._internal.ws.ping(data);
+    } catch (error) {
+      this._internal.hooks.callHook("error", this, new WSError(error));
+    }
   }
 }
 

--- a/src/adapters/node.ts
+++ b/src/adapters/node.ts
@@ -116,6 +116,14 @@ const nodeAdapter: Adapter<NodeAdapter, NodeOptions> = (options = {}) => {
       }
       hooks.callHook("message", peer, new Message(data, peer));
     });
+    // `ws` auto-replies to an inbound ping with a pong per the spec; these
+    // hooks only observe the control frames, they don't need to answer them.
+    ws.on("ping", (data: Buffer) => {
+      hooks.callHook("ping", peer, data);
+    });
+    ws.on("pong", (data: Buffer) => {
+      hooks.callHook("pong", peer, data);
+    });
     ws.on("error", (error: Error) => {
       peers.delete(peer);
       hooks.callHook("error", peer, new WSError(error));
@@ -289,6 +297,10 @@ class NodePeer extends Peer<{
 
   override terminate() {
     this._internal.ws.terminate();
+  }
+
+  override ping(data?: unknown): void {
+    this._internal.ws.ping(data);
   }
 }
 

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -5,6 +5,7 @@ import { toBufferLike } from "../utils.ts";
 import { adapterUtils, getPeers, DEFAULT_IDLE_TIMEOUT } from "../adapter.ts";
 import { AdapterHookable } from "../hooks.ts";
 import { Message } from "../message.ts";
+import { WSError } from "../error.ts";
 import { Peer, type PeerContext } from "../peer.ts";
 import type { SyncDriver } from "../sync.ts";
 import { StubRequest } from "../_request.ts";
@@ -54,7 +55,7 @@ const uwsAdapter: Adapter<UWSAdapter, UWSOptions> = (options = {}) => {
       ...options.uws,
       close(ws, code, message) {
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         ((peer as any)._internal.ws as UwsWebSocketProxy).readyState = 2 /* CLOSING */;
         peers.delete(peer);
         hooks.callHook("close", peer, {
@@ -65,29 +66,36 @@ const uwsAdapter: Adapter<UWSAdapter, UWSOptions> = (options = {}) => {
       },
       message(ws, message, _isBinary) {
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         hooks.callHook("message", peer, new Message(message, peer));
       },
       drain(ws) {
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
-        const peer = getPeer(ws, peers);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         hooks.callHook("drain", peer);
       },
       // uWS auto-replies to an inbound ping with a pong per the spec; these
       // hooks only observe the control frames, they don't need to answer them.
+      // Skip the `Uint8Array` copy entirely when nothing consumes it.
       ping(ws, message) {
+        if (!hooks.options.hooks?.ping && !hooks.options.resolve) {
+          return;
+        }
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         hooks.callHook("ping", peer, new Uint8Array(message));
       },
       pong(ws, message) {
+        if (!hooks.options.hooks?.pong && !hooks.options.resolve) {
+          return;
+        }
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         hooks.callHook("pong", peer, new Uint8Array(message));
       },
       open(ws) {
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
-        const peer = getPeer(ws, peers, baseUtils.sync);
+        const peer = getPeer(ws, peers, baseUtils.sync, hooks);
         peers.add(peer);
         hooks.callHook("open", peer);
       },
@@ -159,7 +167,12 @@ export default uwsAdapter;
 
 // --- peer ---
 
-function getPeer(uws: uws.WebSocket<UserData>, peers: Set<UWSPeer>, sync?: SyncDriver): UWSPeer {
+function getPeer(
+  uws: uws.WebSocket<UserData>,
+  peers: Set<UWSPeer>,
+  sync: SyncDriver | undefined,
+  hooks: AdapterHookable,
+): UWSPeer {
   const uwsData = uws.getUserData();
   if (uwsData.peer) {
     return uwsData.peer;
@@ -172,6 +185,7 @@ function getPeer(uws: uws.WebSocket<UserData>, peers: Set<UWSPeer>, sync?: SyncD
     namespace: uwsData.namespace,
     uwsData,
     sync,
+    hooks,
   });
   uwsData.peer = peer;
   return peer;
@@ -185,6 +199,7 @@ class UWSPeer extends Peer<{
   ws: UwsWebSocketProxy;
   uwsData: UserData;
   sync?: SyncDriver;
+  hooks: AdapterHookable;
 }> {
   override get remoteAddress(): string | undefined {
     try {
@@ -231,7 +246,15 @@ class UWSPeer extends Peer<{
   }
 
   override ping(data?: uws.RecognizedString): number {
-    return this._internal.uws.ping(data);
+    // Guard against uWS rejecting the payload (e.g. the 125-byte control-frame
+    // limit): surface it through the `error` hook rather than letting it crash
+    // a caller inside a hook handler.
+    try {
+      return this._internal.uws.ping(data);
+    } catch (error) {
+      this._internal.hooks.callHook("error", this, new WSError(error));
+      return 0;
+    }
   }
 }
 

--- a/src/adapters/uws.ts
+++ b/src/adapters/uws.ts
@@ -73,6 +73,18 @@ const uwsAdapter: Adapter<UWSAdapter, UWSOptions> = (options = {}) => {
         const peer = getPeer(ws, peers);
         hooks.callHook("drain", peer);
       },
+      // uWS auto-replies to an inbound ping with a pong per the spec; these
+      // hooks only observe the control frames, they don't need to answer them.
+      ping(ws, message) {
+        const peers = getPeers(globalPeers, ws.getUserData().namespace);
+        const peer = getPeer(ws, peers, baseUtils.sync);
+        hooks.callHook("ping", peer, new Uint8Array(message));
+      },
+      pong(ws, message) {
+        const peers = getPeers(globalPeers, ws.getUserData().namespace);
+        const peer = getPeer(ws, peers, baseUtils.sync);
+        hooks.callHook("pong", peer, new Uint8Array(message));
+      },
       open(ws) {
         const peers = getPeers(globalPeers, ws.getUserData().namespace);
         const peer = getPeer(ws, peers, baseUtils.sync);
@@ -216,6 +228,10 @@ class UWSPeer extends Peer<{
 
   override terminate(): void {
     this._internal.uws.close();
+  }
+
+  override ping(data?: uws.RecognizedString): number {
+    return this._internal.uws.ping(data);
   }
 }
 

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -214,4 +214,24 @@ export interface Hooks {
 
   /** An error occurs */
   error: (peer: Peer, error: WSError) => MaybePromise<void>;
+
+  /**
+   * An application-level WebSocket ping control frame was received from the
+   * peer (e.g. sent by the client, or by another server via
+   * {@link Peer.ping}).
+   *
+   * **Note:** Only emitted by adapters that surface inbound ping frames.
+   * Refer to the [compatibility table](https://crossws.h3.dev/guide/peer#compatibility).
+   */
+  ping: (peer: Peer, data: Uint8Array) => MaybePromise<void>;
+
+  /**
+   * An application-level WebSocket pong control frame was received from the
+   * peer, typically in reply to {@link Peer.ping}. Use together with a
+   * timestamp embedded in the ping payload to measure round-trip latency.
+   *
+   * **Note:** Only emitted by adapters that surface inbound pong frames.
+   * Refer to the [compatibility table](https://crossws.h3.dev/guide/peer#compatibility).
+   */
+  pong: (peer: Peer, data: Uint8Array) => MaybePromise<void>;
 }

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -173,6 +173,21 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
     this.close();
   }
 
+  /**
+   * Send an application-level WebSocket ping control frame to the client.
+   *
+   * Pair with the {@link Hooks.pong} hook (e.g. embedding a timestamp in
+   * `data`) to measure round-trip latency, or rely on the {@link Hooks.ping}
+   * hook to observe pings the client sends unprompted.
+   *
+   * **Note:** Not all adapters can send a ping frame; unsupported adapters
+   * warn and no-op. Refer to the
+   * [compatibility table](https://crossws.h3.dev/guide/peer#compatibility).
+   */
+  ping(_data?: unknown): number | void | undefined {
+    console.warn("[crossws] `peer.ping()` is not supported by this adapter.");
+  }
+
   /** Subscribe to a topic */
   subscribe(topic: string): void {
     this._topics.add(topic);

--- a/src/peer.ts
+++ b/src/peer.ts
@@ -42,6 +42,7 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
   protected _id?: string;
 
   #ws?: Partial<web.WebSocket>;
+  #pingUnsupportedWarned = false;
 
   constructor(internal: Internal) {
     this._topics = new Set();
@@ -180,12 +181,21 @@ export abstract class Peer<Internal extends AdapterInternal = AdapterInternal> {
    * `data`) to measure round-trip latency, or rely on the {@link Hooks.ping}
    * hook to observe pings the client sends unprompted.
    *
+   * `data` is optional and, per RFC 6455, must not exceed 125 bytes (a ping is
+   * a control frame); an over-long or otherwise invalid payload is reported via
+   * the {@link Hooks.error} hook instead of being sent.
+   *
    * **Note:** Not all adapters can send a ping frame; unsupported adapters
-   * warn and no-op. Refer to the
+   * warn once and no-op. Refer to the
    * [compatibility table](https://crossws.h3.dev/guide/peer#compatibility).
    */
   ping(_data?: unknown): number | void | undefined {
-    console.warn("[crossws] `peer.ping()` is not supported by this adapter.");
+    // Warn once per peer instead of on every call, so a heartbeat loop against
+    // an unsupported adapter can't spam the console.
+    if (!this.#pingUnsupportedWarned) {
+      this.#pingUnsupportedWarned = true;
+      console.warn("[crossws] `peer.ping()` is not supported by this adapter.");
+    }
   }
 
   /** Subscribe to a topic */

--- a/src/server/_resolve.ts
+++ b/src/server/_resolve.ts
@@ -3,7 +3,16 @@ import type { Server } from "srvx";
 import type { Hooks } from "../hooks";
 import type { WSOptions } from "./_types";
 
-const HOOK_NAMES = ["upgrade", "message", "open", "close", "drain", "error"] as const;
+const HOOK_NAMES = [
+  "upgrade",
+  "message",
+  "open",
+  "close",
+  "drain",
+  "error",
+  "ping",
+  "pong",
+] as const;
 
 // Compile-time guard: if a hook is added to `Hooks` but not listed above, the
 // leftover key is no longer `never`, so this type resolves to a tuple and the

--- a/test/adapters/bun.test.ts
+++ b/test/adapters/bun.test.ts
@@ -1,6 +1,10 @@
 import { describe } from "vitest";
 import { wsTestsExec } from "../_utils";
+import { wsTests, pingPongTests } from "../tests";
 
 describe("bun", () => {
-  wsTestsExec("bun run ./bun.ts", { adapter: "bun" });
+  wsTestsExec("bun run ./bun.ts", { adapter: "bun" }, (getURL, opts) => {
+    wsTests(getURL, opts);
+    pingPongTests(getURL);
+  });
 });

--- a/test/adapters/node.test.ts
+++ b/test/adapters/node.test.ts
@@ -5,7 +5,7 @@ import { getRandomPort, waitForPort } from "get-port-please";
 import nodeAdapter from "../../src/adapters/node";
 import { defineHooks } from "../../src/index";
 import { createDemo } from "../fixture/_shared";
-import { wsTests } from "../tests";
+import { wsTests, pingPongTests } from "../tests";
 import { wsConnect } from "../_utils";
 
 describe("node", () => {
@@ -50,6 +50,8 @@ describe("node", () => {
   wsTests(() => url, {
     adapter: "node",
   });
+
+  pingPongTests(() => url);
 
   test("forcefully terminates when force=true", async () => {
     ws.closeAll(undefined, undefined, true);

--- a/test/adapters/uws.test.ts
+++ b/test/adapters/uws.test.ts
@@ -9,7 +9,7 @@ import {
 import uwsAdapter from "../../src/adapters/uws";
 import { defineHooks } from "../../src/index";
 import { createDemo } from "../fixture/_shared";
-import { wsTests } from "../tests";
+import { wsTests, pingPongTests } from "../tests";
 import { wsConnect } from "../_utils";
 
 describe("uws", () => {
@@ -67,6 +67,8 @@ describe("uws", () => {
   wsTests(() => url, {
     adapter: "uws",
   });
+
+  pingPongTests(() => url);
 });
 
 // Regression: a global `adapter.publish(topic, data)` (no namespace) on a

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -55,11 +55,21 @@ export function createDemo<T extends Adapter<any, any>>(
           });
           break;
         }
+        case "ping-me": {
+          peer.ping("server-ping");
+          break;
+        }
         default: {
           peer.send(msgText);
           peer.publish("chat", msgText);
         }
       }
+    },
+    ping(peer, data) {
+      peer.send(`ping-received:${new TextDecoder().decode(data)}`);
+    },
+    pong(peer, data) {
+      peer.send(`pong-received:${new TextDecoder().decode(data)}`);
     },
     upgrade(req) {
       if (req.url.endsWith("?unauthorized")) {

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "vitest";
+import { WebSocket as NodeWebSocket } from "ws";
 import { wsConnect } from "./_utils";
 
 export interface WSTestOpts {
@@ -198,4 +199,72 @@ export function wsTests(getURL: () => string, opts: WSTestOpts): void {
       expect(await ws2.next()).toBe("ping");
     },
   );
+}
+
+/**
+ * Application-level ping/pong control frames aren't reachable through the
+ * standard `WebSocket` API (browsers/undici auto-answer them invisibly to
+ * JS), so — unlike {@link wsTests} — this suite connects with the `ws`
+ * package, which exposes `.ping()`/`.pong()` and the raw `ping`/`pong`
+ * events. Only wired up for adapters that support it (node, uws, bun); refer
+ * to the [compatibility table](https://crossws.h3.dev/guide/peer#compatibility).
+ */
+export function pingPongTests(getURL: () => string): void {
+  // Queues inbound text messages (attached before `open` resolves, so the
+  // fixture's immediate "Welcome ..." message can't be missed in the race
+  // between connecting and a test attaching its own listener) so a test can
+  // skip past it and assert on the next message deterministically.
+  const connect = () => {
+    const client = new NodeWebSocket(getURL());
+    const messages: string[] = [];
+    const waitCallbacks: Record<number, (message: string) => void> = {};
+    let nextIndex = 0;
+    client.on("message", (data) => {
+      const text = data.toString();
+      const index = messages.push(text) - 1;
+      waitCallbacks[index]?.(text);
+      delete waitCallbacks[index];
+    });
+    const next = (): Promise<string> => {
+      const index = nextIndex++;
+      if (index < messages.length) {
+        return Promise.resolve(messages[index]!);
+      }
+      return new Promise((resolve) => {
+        waitCallbacks[index] = resolve;
+      });
+    };
+    return new Promise<{ client: NodeWebSocket; next: () => Promise<string> }>(
+      (resolve, reject) => {
+        client.once("open", () => resolve({ client, next }));
+        client.once("error", reject);
+      },
+    );
+  };
+
+  test("ping hook observes an inbound ping from the client", async () => {
+    const { client, next } = await connect();
+    await next(); // "Welcome ..." from the `open` hook
+    client.ping("client-ping");
+    expect(await next()).toBe("ping-received:client-ping");
+    client.close();
+  });
+
+  test("pong hook observes an inbound pong from the client", async () => {
+    const { client, next } = await connect();
+    await next(); // "Welcome ..." from the `open` hook
+    client.pong("client-pong");
+    expect(await next()).toBe("pong-received:client-pong");
+    client.close();
+  });
+
+  test("peer.ping() sends a ping frame the client receives", async () => {
+    const { client } = await connect();
+    const pingReceived = new Promise<string>((resolve) => {
+      client.once("ping", (data) => resolve(data.toString()));
+    });
+    client.send("ping-me");
+    expect(await pingReceived).toBe("server-ping");
+    client.close();
+  });
 }

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -216,22 +216,25 @@ export function pingPongTests(getURL: () => string): void {
   // skip past it and assert on the next message deterministically.
   const connect = () => {
     const client = new NodeWebSocket(getURL());
-    const messages: string[] = [];
-    const waitCallbacks: Record<number, (message: string) => void> = {};
-    let nextIndex = 0;
+    const queue: string[] = [];
+    let pending: ((message: string) => void) | undefined;
     client.on("message", (data) => {
       const text = data.toString();
-      const index = messages.push(text) - 1;
-      waitCallbacks[index]?.(text);
-      delete waitCallbacks[index];
+      if (pending) {
+        pending(text);
+        pending = undefined;
+      } else {
+        queue.push(text);
+      }
     });
+    // The tests only ever await `next()` sequentially, so a plain FIFO queue
+    // with a single pending resolver is enough.
     const next = (): Promise<string> => {
-      const index = nextIndex++;
-      if (index < messages.length) {
-        return Promise.resolve(messages[index]!);
+      if (queue.length > 0) {
+        return Promise.resolve(queue.shift()!);
       }
       return new Promise((resolve) => {
-        waitCallbacks[index] = resolve;
+        pending = resolve;
       });
     };
     return new Promise<{ client: NodeWebSocket; next: () => Promise<string> }>(


### PR DESCRIPTION
## Summary

Closes #154 (the remaining follow-up scope after #201 landed automatic server-side liveness):

- Adds `ping(peer, data)` / `pong(peer, data)` hooks to the `Hooks` interface, firing when an application-level ping/pong control frame arrives from the peer.
- Adds `peer.ping(data?)` to send an application-level ping.
- Wired natively for **Node (`ws`)**, **uWebSockets** (previously dropped its `ping`/`pong` behavior handlers), and **Bun** (which turns out to fully support `ws.ping()`/`ws.pong()` and `ping`/`pong` handlers, better than the issue assumed). Deno, Cloudflare (incl. Durable Objects), Bunny, and SSE have no such control-frame API exposed to user code, so `peer.ping()` warns and no-ops there and the hooks never fire.
- Documents a compatibility matrix for `ping()` / `ping`+`pong` hooks alongside the existing `drain` row in the peer guide, and adds both hooks to the hooks guide example.

Every runtime already auto-replies to an inbound ping with a pong per the WebSocket spec — these hooks only *observe* the control frames, they don't need to answer them.

## Test plan

- [x] `pnpm lint` / `pnpm typecheck` pass
- [x] `pnpm vitest run` — full suite green (248 passed, 6 skipped)
- [x] New tests added in `test/tests.ts` (`pingPongTests`, using the `ws` package client since raw ping/pong control frames aren't reachable through the standard `WebSocket` API), wired into `node.test.ts`, `uws.test.ts`, and `bun.test.ts`:
  - inbound client ping → `ping` hook fires
  - inbound client pong → `pong` hook fires
  - `peer.ping()` → client observes a real ping frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for WebSocket ping/pong events in supported adapters.
  * Introduced a `ping()` method on peers to send ping frames and help measure connection latency.
  * Expanded documentation with examples and compatibility notes for ping/pong handling.

* **Bug Fixes**
  * Improved runtime compatibility by handling ping/pong frames consistently across supported environments.
  * Added coverage to verify ping/pong behavior end to end.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->