### PR TITLE
feat: opt-in WebSocket subprotocol negotiation

### DIFF
--- a/docs/1.guide/2.hooks.md
+++ b/docs/1.guide/2.hooks.md
@@ -133,3 +133,35 @@ const hooks = defineHooks({
   },
 });
 ```
+
+## Subprotocol negotiation
+
+When a client opens a connection with subprotocols (`new WebSocket(url, ["graphql-transport-ws"])`), it sends them in the `Sec-WebSocket-Protocol` request header. Browsers **reject** the connection unless the server's handshake response accepts one of the offered subprotocols. By default crossws accepts none — a server never claims to speak a protocol you didn't opt into — so you have to select one.
+
+Return `protocol` from the `upgrade` hook to accept a subprotocol for that connection. It should be one of the values the client offered.
+
+```ts
+import { defineHooks } from "crossws";
+
+const hooks = defineHooks({
+  upgrade(req) {
+    const offered = req.headers.get("sec-websocket-protocol"); // "graphql-transport-ws, graphql-ws"
+    if (offered?.split(",").some((p) => p.trim() === "graphql-transport-ws")) {
+      return { protocol: "graphql-transport-ws" };
+    }
+  },
+});
+```
+
+For a global default that applies to every connection, use the [`handleProtocols`](/adapters#options) adapter option instead. It receives the set of offered subprotocols and returns the one to accept (or `false` for none); a `protocol` returned from the `upgrade` hook takes precedence over it.
+
+```ts
+crossws({
+  handleProtocols: (protocols) =>
+    protocols.has("graphql-transport-ws") ? "graphql-transport-ws" : false,
+  hooks,
+});
+```
+
+> [!NOTE]
+> Support is consistent across the Node, Bun and Deno adapters. Bun additionally echoes the first offered subprotocol even when none is selected ([oven-sh/bun#18243](https://github.com/oven-sh/bun/issues/18243)).

--- a/docs/2.adapters/1.index.md
+++ b/docs/2.adapters/1.index.md
@@ -24,3 +24,18 @@ It maps to each runtime's liveness mechanism behind one consistent knob:
 Terminated peers surface through the normal `close` hook (Node reports code `1006`), so `close`/`error` teardown runs unchanged.
 
 **Defaults to `30` (seconds) on every runtime.** 30s stays under the common ~60s reverse-proxy / load-balancer idle timeout (so idle-but-alive connections aren't dropped) while reclaiming dead sockets promptly; pings are a few bytes and standards clients auto-pong, so a live connection is never disconnected. Set to `0` to disable.
+
+### `handleProtocols`
+
+Select the WebSocket subprotocol to accept during the handshake. Browsers that open `new WebSocket(url, protocols)` send their offer in the `Sec-WebSocket-Protocol` request header and **reject the connection** unless the server echoes one of the offered values back. By default crossws accepts none, so supply this to negotiate one:
+
+```ts
+crossws({
+  handleProtocols: (protocols /* Set<string> */, request) =>
+    protocols.has("graphql-transport-ws") ? "graphql-transport-ws" : false,
+});
+```
+
+It is called only when the client offered at least one subprotocol, and receives the set of offered values plus the upgrade `request`. Return the single subprotocol to accept (one of the offered values), or `false`/`undefined` for none. It may be async.
+
+This is the global default; the [`upgrade` hook](/guide/hooks#subprotocol-negotiation) can return `{ protocol }` to override it per connection. Consistent across the Node, Bun and Deno adapters.

--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -1,4 +1,4 @@
-import type { Hooks, ResolveHooks } from "./hooks.ts";
+import type { Hooks, MaybePromise, ResolveHooks } from "./hooks.ts";
 import type { Peer } from "./peer.ts";
 import type { SyncAdapter, SyncDriver, SyncMessage } from "./sync.ts";
 import { serializeMessage } from "./utils.ts";
@@ -186,6 +186,32 @@ export interface AdapterOptions {
   resolve?: ResolveHooks;
   getNamespace?: (request: Request) => string;
   hooks?: Partial<Hooks>;
+
+  /**
+   * Select the WebSocket subprotocol to accept during the handshake.
+   *
+   * Browsers that open `new WebSocket(url, protocols)` send their offer in the
+   * `Sec-WebSocket-Protocol` request header and **reject the connection** if
+   * the server's `101` response doesn't echo one of the offered values back.
+   * By default crossws negotiates nothing (a server never claims to speak a
+   * protocol the app didn't opt into), so supply this to accept one.
+   *
+   * Called with the set of subprotocols the client offered and the upgrade
+   * request. Return the single subprotocol to accept (must be one of the
+   * offered values), or `false`/`undefined` to accept none. Only invoked when
+   * the client actually offered at least one subprotocol.
+   *
+   * This is the global default; the {@link Hooks.upgrade} hook may return
+   * `{ protocol }` to override it per connection.
+   *
+   * @example
+   * handleProtocols: (protocols) =>
+   *   protocols.has("graphql-transport-ws") ? "graphql-transport-ws" : false
+   */
+  handleProtocols?: (
+    protocols: Set<string>,
+    request: Request,
+  ) => MaybePromise<string | false | null | undefined>;
   /**
    * Optional sync backplane to relay pub/sub between multiple crossws
    * instances (e.g. across regions/processes). Opt-in: when absent, pub/sub

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -93,12 +93,16 @@ export class AdapterHookable {
     context: PeerContext;
     namespace: string;
     upgradeHeaders?: HeadersInit;
+    protocol?: string;
     endResponse?: Response;
     handled?: boolean;
   }> {
     let namespace = this.options.getNamespace?.(request) ?? new URL(request.url).pathname;
 
     const context = request.context || {};
+
+    let upgradeHeaders: HeadersInit | undefined;
+    let protocolFromHook: string | undefined;
 
     try {
       // Seed the per-connection resolve cache against `context` so every later
@@ -109,30 +113,24 @@ export class AdapterHookable {
         undefined,
         context,
       );
-      if (!res) {
-        return { context, namespace };
-      }
-      if ((res as { namespace?: string }).namespace) {
-        namespace = (res as { namespace: string }).namespace;
-      }
-      if ((res as { context?: Record<string, unknown> }).context) {
-        Object.assign(context, (res as { context?: Record<string, unknown> }).context);
-      }
-      if (res instanceof Response) {
-        return { context, namespace, endResponse: res };
-      }
-      if ((res as { handled?: boolean }).handled) {
-        // Hook took ownership of the socket — any `headers` returned
-        // alongside `handled` are ignored since the adapter skips its
-        // own upgrade and no response will be written from here.
-        return { context, namespace, handled: true };
-      }
-      if (res.headers) {
-        return {
-          context,
-          namespace,
-          upgradeHeaders: res.headers,
-        };
+      if (res) {
+        if ((res as { namespace?: string }).namespace) {
+          namespace = (res as { namespace: string }).namespace;
+        }
+        if ((res as { context?: Record<string, unknown> }).context) {
+          Object.assign(context, (res as { context?: Record<string, unknown> }).context);
+        }
+        if (res instanceof Response) {
+          return { context, namespace, endResponse: res };
+        }
+        if ((res as { handled?: boolean }).handled) {
+          // Hook took ownership of the socket — any `headers`/`protocol`
+          // returned alongside `handled` are ignored since the adapter skips
+          // its own upgrade and no response will be written from here.
+          return { context, namespace, handled: true };
+        }
+        upgradeHeaders = res.headers;
+        protocolFromHook = (res as { protocol?: string }).protocol;
       }
     } catch (error) {
       const errResponse = (error as { response: Response }).response || error;
@@ -145,8 +143,76 @@ export class AdapterHookable {
       }
       throw error;
     }
-    return { context, namespace };
+
+    // Resolve the negotiated subprotocol (opt-in; strict/no-echo by default).
+    // Adapters don't need to know about any of this: every runtime turns a
+    // `sec-websocket-protocol` entry in `upgradeHeaders` into the accepted
+    // subprotocol (Node re-emits it via ws's `headers` event, Deno reads it
+    // into its native `protocol` option, Bun forwards it to `server.upgrade`),
+    // so folding the choice back into the headers here keeps negotiation
+    // consistent across all of them from a single place.
+    const protocol = await this._resolveProtocol(request, upgradeHeaders, protocolFromHook);
+    if (protocol) {
+      const merged = new Headers(upgradeHeaders);
+      merged.set("sec-websocket-protocol", protocol);
+      upgradeHeaders = merged;
+    }
+
+    return { context, namespace, upgradeHeaders, protocol };
   }
+
+  // Pick the subprotocol to accept, in precedence order:
+  //   1. `protocol` returned explicitly from the `upgrade` hook (per-connection).
+  //   2. a `sec-websocket-protocol` header set directly by the hook (the
+  //      pre-existing way to negotiate, kept working verbatim).
+  //   3. the `handleProtocols(protocols, request)` adapter option (global
+  //      default), mirroring ws's own selector signature.
+  // Returns `undefined` to accept no subprotocol — the strict default, so a
+  // server never claims to speak a protocol the app didn't opt into.
+  async _resolveProtocol(
+    request: Request,
+    upgradeHeaders: HeadersInit | undefined,
+    protocolFromHook: string | undefined,
+  ): Promise<string | undefined> {
+    if (protocolFromHook) {
+      return protocolFromHook;
+    }
+    if (upgradeHeaders) {
+      const headers =
+        upgradeHeaders instanceof Headers ? upgradeHeaders : new Headers(upgradeHeaders);
+      const fromHeader = headers.get("sec-websocket-protocol");
+      if (fromHeader) {
+        return fromHeader;
+      }
+    }
+    const handleProtocols = this.options.handleProtocols;
+    if (handleProtocols) {
+      const offered = _parseProtocols(request.headers.get("sec-websocket-protocol"));
+      if (offered.size > 0) {
+        const chosen = await handleProtocols(offered, request);
+        if (chosen) {
+          return chosen;
+        }
+      }
+    }
+    return undefined;
+  }
+}
+
+// Parse a `sec-websocket-protocol` request header ("a, b , c") into the set of
+// distinct, trimmed subprotocol tokens the client offered.
+function _parseProtocols(header: string | null | undefined): Set<string> {
+  const protocols = new Set<string>();
+  if (!header) {
+    return protocols;
+  }
+  for (const part of header.split(",")) {
+    const token = part.trim();
+    if (token) {
+      protocols.add(token);
+    }
+  }
+  return protocols;
 }
 
 // --- types ---
@@ -169,6 +235,12 @@ export interface Hooks {
    *
    * - You can throw a Response to abort the upgrade.
    * - You can return { headers } to modify the response.
+   * - You can return { protocol } to accept a WebSocket subprotocol for this
+   *   connection (echoed back as `Sec-WebSocket-Protocol`). This is the
+   *   per-connection counterpart to the global
+   *   {@link AdapterOptions.handleProtocols} option and takes precedence over
+   *   it. It should be one of the subprotocols the client offered (the values
+   *   in the request's `Sec-WebSocket-Protocol` header).
    * - You can return { namespace } to change the pub/sub namespace.
    * - You can return { context } to provide a custom peer context.
    * - You can return { handled: true } to signal that the upgrade has
@@ -186,6 +258,7 @@ export interface Hooks {
   ) => MaybePromise<
     | {
         headers?: HeadersInit;
+        protocol?: string;
         namespace?: string;
         context?: PeerContext;
         handled?: boolean;

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -93,7 +93,6 @@ export class AdapterHookable {
     context: PeerContext;
     namespace: string;
     upgradeHeaders?: HeadersInit;
-    protocol?: string;
     endResponse?: Response;
     handled?: boolean;
   }> {
@@ -158,7 +157,7 @@ export class AdapterHookable {
       upgradeHeaders = merged;
     }
 
-    return { context, namespace, upgradeHeaders, protocol };
+    return { context, namespace, upgradeHeaders };
   }
 
   // Pick the subprotocol to accept, in precedence order:

--- a/test/fixture/_shared.ts
+++ b/test/fixture/_shared.ts
@@ -90,19 +90,32 @@ export function createDemo<T extends Adapter<any, any>>(
         "x-powered-by": "cross-ws",
         "set-cookie": "cross-ws=1; SameSite=None; Secure",
       };
-      if (req.headers.get("sec-websocket-protocol") === "supported") {
+      const reqProtocol = req.headers.get("sec-websocket-protocol");
+      // Negotiate via a header set directly by the hook (the original way).
+      if (reqProtocol === "supported") {
         headers["sec-websocket-protocol"] = "supported";
       }
-      return {
+      const result: {
+        context: Record<string, string>;
+        headers: Record<string, string>;
+        protocol?: string;
+      } = {
         context: { test: "1" },
         headers,
       };
+      // Negotiate via the first-class per-connection `protocol` return field.
+      if (reqProtocol === "graphql-transport-ws") {
+        result.protocol = "graphql-transport-ws";
+      }
+      return result;
     },
   });
 
   return adapter({
     ...options,
     hooks,
+    // Global default selector: negotiate via the `handleProtocols` option.
+    handleProtocols: (protocols: Set<string>) => (protocols.has("chat") ? "chat" : false),
   });
 }
 

--- a/test/tests.ts
+++ b/test/tests.ts
@@ -87,6 +87,32 @@ export function wsTests(getURL: () => string, opts: WSTestOpts): void {
     }
   });
 
+  // Negotiate via the per-connection `protocol` field returned from `upgrade()`.
+  test.runIf(/^(node|bun|deno)$/.test(opts.adapter))(
+    "negotiate sub-protocol via upgrade() protocol field",
+    async () => {
+      const ws = await wsConnect(getURL(), {
+        headers: { "sec-websocket-protocol": "graphql-transport-ws" },
+      });
+      expect(ws.inspector.headers).toMatchObject({
+        "sec-websocket-protocol": "graphql-transport-ws",
+      });
+    },
+  );
+
+  // Negotiate via the global `handleProtocols` adapter option.
+  test.runIf(/^(node|bun|deno)$/.test(opts.adapter))(
+    "negotiate sub-protocol via handleProtocols option",
+    async () => {
+      const ws = await wsConnect(getURL(), {
+        headers: { "sec-websocket-protocol": "chat" },
+      });
+      expect(ws.inspector.headers).toMatchObject({
+        "sec-websocket-protocol": "chat",
+      });
+    },
+  );
+
   test("peer.request (headers, url, remoteAddress)", async () => {
     const ws = await wsConnect(getURL() + "?foo=bar", {
       skip: 1,


### PR DESCRIPTION
Closes #176.

## Problem

Browsers open connections with `new WebSocket(url, protocols)` and send the offer in the `Sec-WebSocket-Protocol` request header. They **reject the connection** unless the server's `101` echoes one of the offered subprotocols back. crossws negotiated none by default (Node hardcoded `handleProtocols: () => false`, Deno/others didn't echo either), so browser clients using standard protocols like `graphql-transport-ws` / `graphql-ws` (GraphQL Yoga, Apollo, …) failed to connect.

The existing workaround — setting the header yourself in the `upgrade` hook — worked for `ws` clients but was undiscoverable boilerplate.

## Change

Two opt-in ways to accept a subprotocol:

```ts
// Global default (AdapterOptions) — mirrors ws's selector signature
crossws({
  handleProtocols: (protocols, request) =>
    protocols.has("graphql-transport-ws") ? "graphql-transport-ws" : false,
});

// Per-connection override (upgrade hook), takes precedence
defineHooks({
  upgrade: (req) => ({ protocol: "graphql-transport-ws" }),
});
```

The choice is resolved centrally in `hooks.upgrade()` and folded into the upgrade headers. Every adapter already turns a `sec-websocket-protocol` entry in the upgrade headers into the accepted subprotocol (Node re-emits it via ws's `headers` event, Deno reads it into its native `protocol`, Bun forwards it to `server.upgrade`), so **Node, Bun and Deno stay consistent with no per-adapter logic**.

Resolution precedence: `upgrade()` `{ protocol }` → a `sec-websocket-protocol` header the hook set directly (pre-existing way, kept working) → `handleProtocols` option → none.

**Default stays strict** (accept none) so a server never claims a subprotocol the app didn't opt into.

## Verified on the wire (Node)

```
upgrade() {protocol} field  -> sec-websocket-protocol: graphql-transport-ws
handleProtocols option      -> sec-websocket-protocol: chat        (picked from "chat, superchat")
not selected (strict)       -> (none)
```

> Note: Bun additionally echoes the first offered subprotocol even when none is selected (oven-sh/bun#18243) — documented, not fixable from our side.

## Tests / docs

- Shared fixture exercises all three paths (`{ protocol }`, header, `handleProtocols`); new tests gated to node/bun/deno.
- 254 tests pass (all suites incl. spawned Bun/Deno), typecheck + lint clean.
- Docs: new "Subprotocol negotiation" guide section + `handleProtocols` in shared adapter options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for WebSocket subprotocol negotiation, including a global default option and per-connection selection.
  * Documented how accepted subprotocols are chosen during the handshake across supported adapters.

* **Bug Fixes**
  * Improved handshake handling so negotiated subprotocols are consistently applied to the connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->