### PR TITLE
feat(proxy): add `clientIdleTimeout` to reclaim silent clients

### DIFF
--- a/docs/1.guide/8.proxy.md
+++ b/docs/1.guide/8.proxy.md
@@ -236,6 +236,26 @@ const hooks = createWebSocketProxy({
 > [!IMPORTANT]
 > The WHATWG global `WebSocket` constructor does **not** accept custom headers. `headers` is only honored when a `WebSocket` constructor that takes a third options argument is passed via the [`WebSocket` option](#custom-websocket-constructor) — e.g. [`ws`](https://github.com/websockets/ws) or [`undici`](https://undici.nodejs.org). With the global constructor the option is silently ignored.
 
+## Client idle timeout
+
+Sometimes a client disappears without closing its connection — the network drops, the device sleeps, or a proxy or tunnel between the client and your server quietly stops passing traffic. The upstream connection stays open, tying up resources for a client that will never return.
+
+Normally WebSocket ping/pong keepalive would notice a dead connection, but it isn't always enough: when there's a proxy or tunnel in the middle, that middlebox can answer the pings itself, so the connection keeps looking healthy long after the real client is gone.
+
+`clientIdleTimeout` catches these by watching for **actual messages from the client**. Each message the client sends resets the timer; traffic the server pushes to the client does not. If nothing arrives from the client within the window, the proxy closes both the peer (code `1001`) and the upstream connection.
+
+```ts
+createWebSocketProxy({
+  target: "wss://backend.example.com",
+  // Close a client that sends nothing for 60s. Assumes the protocol has the
+  // client send periodic traffic (e.g. a heartbeat / keepalive message).
+  clientIdleTimeout: 60_000,
+});
+```
+
+> [!WARNING]
+> Only enable this for protocols where the client is expected to send traffic periodically. For **server-push-only** protocols where the client may be legitimately silent, a `clientIdleTimeout` will close idle-but-live connections — leave it disabled (the default) in that case.
+
 ## API
 
 ### `createWebSocketProxy(target)`
@@ -254,6 +274,7 @@ Accepts either a target URL (`string` or `URL`), a resolver function, or an opti
 - **`webSocketOptions`** — `Record<string, unknown> | (peer: Peer) => Record<string, unknown>`. Extra dialing options passed to the upstream `WebSocket` client, statically or per peer. The escape hatch for transport options the URL can't express — e.g. the `ws`/`undici` `createConnection`/`dispatcher`/`agent`, or a custom `Deno.createHttpClient` `client`. Merged with `headers` (the `headers` option wins over a `headers` key returned here). See [per-peer constructor options](#per-peer-constructor-options). Only honored by clients that accept dialing options (`ws`/`undici`, or Deno's global); the WHATWG browser global ignores them.
 - **`maxBufferSize`** — `number` (default `1048576`, i.e. 1 MiB). Maximum number of bytes buffered per peer while the upstream is still connecting. String frames are accounted at their UTF-8 worst case (3 bytes per UTF-16 code unit) to avoid undercounting multi-byte content. When exceeded, the peer is closed with code `1009` (Message Too Big). Set to `0` to disable.
 - **`connectTimeout`** — `number` (default `10000`). Milliseconds to wait for the upstream WebSocket handshake to complete — and, for an async `target` resolver, for the resolver to settle. If exceeded, the peer is closed with code `1011`. Set to `0` to disable.
+- **`clientIdleTimeout`** — `number` (default `0`, disabled). Milliseconds of **client→proxy** inactivity after which the peer and upstream are closed with code `1001`. Reset by every inbound client frame; unaffected by upstream→client traffic. Only suitable for protocols where the client sends traffic periodically. See [client idle timeout](#client-idle-timeout). Set to `0` to disable.
 - **`WebSocket`** — `typeof WebSocket` (default `globalThis.WebSocket`). Custom `WebSocket` constructor used to dial the upstream. Falls back to the global when omitted; throws at setup time if neither is available.
 
 Returns a `Partial<Hooks>` object containing `upgrade`, `open`, `message`, `close`, and `error` hooks.

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -87,6 +87,24 @@ export interface WebSocketProxyOptions {
   connectTimeout?: number;
 
   /**
+   * Milliseconds of **client→proxy** inactivity after which both the peer
+   * and the upstream connection are closed (peer close code `1001`).
+   *
+   * The timer is reset by every inbound frame the client sends and is
+   * unaffected by upstream→client traffic. This is driven by real application frames, so
+   * it reclaims a connection whose client vanished behind such an
+   * intermediary and left the upstream socket dangling.
+   *
+   * Only enable this for protocols where the client is expected to send
+   * traffic periodically (e.g. a heartbeat / keepalive message). For
+   * server-push-only protocols where the client may be legitimately silent,
+   * leave it disabled or it will close idle-but-live connections.
+   *
+   * @default 0 (disabled)
+   */
+  clientIdleTimeout?: number;
+
+  /**
    * Custom `WebSocket` constructor used to dial the upstream. Useful when
    * the runtime does not expose a global `WebSocket` (Node.js < 22) or
    * when you want to use a different client implementation (e.g. `ws`,
@@ -188,6 +206,7 @@ export function createWebSocketProxy(
   }
 
   const upstreams = new Map<string, UpstreamState>();
+  const clientIdleTimeoutMs = options.clientIdleTimeout ?? 0;
 
   return {
     upgrade(request) {
@@ -219,6 +238,8 @@ export function createWebSocketProxy(
         bufferSize: 0,
         open: false,
         timeout: undefined,
+        idleTimer: undefined,
+        lastActivity: Date.now(),
       };
       upstreams.set(peer.id, state);
 
@@ -231,6 +252,23 @@ export function createWebSocketProxy(
           _cleanupState(upstreams, peer.id, state);
           _safeClose(peer, 1011, "Upstream connect timeout");
         }, timeoutMs);
+      }
+
+      // Client-inactivity watchdog. Re-arms itself for the remaining window
+      // rather than clearing/setting a timer on every inbound frame, so a
+      // chatty client only pays a timestamp write per message.
+      if (clientIdleTimeoutMs > 0) {
+        const checkIdle = () => {
+          if (upstreams.get(peer.id) !== state) return;
+          const remaining = clientIdleTimeoutMs - (Date.now() - state.lastActivity);
+          if (remaining <= 0) {
+            _cleanupState(upstreams, peer.id, state);
+            _safeClose(peer, 1001, "Client idle timeout");
+          } else {
+            state.idleTimer = setTimeout(checkIdle, remaining);
+          }
+        };
+        state.idleTimer = setTimeout(checkIdle, clientIdleTimeoutMs);
       }
 
       let resolved: URL | Promise<URL>;
@@ -260,6 +298,9 @@ export function createWebSocketProxy(
     message(peer, message) {
       const state = upstreams.get(peer.id);
       if (!state) return;
+      // Any inbound client frame is proof of a live client — reset the
+      // inactivity watchdog (the re-arming timer reads this on its next tick).
+      if (clientIdleTimeoutMs > 0) state.lastActivity = Date.now();
       const raw = typeof message.rawData === "string" ? message.rawData : message.uint8Array();
       if (state.open) {
         try {
@@ -294,6 +335,7 @@ export function createWebSocketProxy(
       const state = upstreams.get(peer.id);
       if (!state) return;
       _clearTimeout(state);
+      _clearIdleTimer(state);
       upstreams.delete(peer.id);
       try {
         // `ws` is undefined if the peer closed while an async target was still
@@ -308,6 +350,7 @@ export function createWebSocketProxy(
       const state = upstreams.get(peer.id);
       if (!state) return;
       _clearTimeout(state);
+      _clearIdleTimer(state);
       upstreams.delete(peer.id);
       try {
         state.ws?.close(1011, "Peer error");
@@ -327,6 +370,8 @@ interface UpstreamState {
   bufferSize: number;
   open: boolean;
   timeout: ReturnType<typeof setTimeout> | undefined;
+  idleTimer: ReturnType<typeof setTimeout> | undefined;
+  lastActivity: number;
 }
 
 // Dial the upstream once the target URL is known (synchronously, or after an
@@ -418,6 +463,7 @@ function _cleanupState(
   state: UpstreamState,
 ): void {
   _clearTimeout(state);
+  _clearIdleTimer(state);
   upstreams.delete(id);
   try {
     state.ws?.close();
@@ -430,6 +476,13 @@ function _clearTimeout(state: UpstreamState): void {
   if (state.timeout !== undefined) {
     clearTimeout(state.timeout);
     state.timeout = undefined;
+  }
+}
+
+function _clearIdleTimer(state: UpstreamState): void {
+  if (state.idleTimer !== undefined) {
+    clearTimeout(state.idleTimer);
+    state.idleTimer = undefined;
   }
 }
 

--- a/test/proxy.test.ts
+++ b/test/proxy.test.ts
@@ -18,12 +18,14 @@ describe("createWebSocketProxy", () => {
   let limitedProxyServer: Server;
   let badProxyServer: Server;
   let timeoutProxyServer: Server;
+  let idleProxyServer: Server;
   let upstreamURL: string;
   let proxyURL: string;
   let dynamicProxyURL: string;
   let limitedProxyURL: string;
   let badProxyURL: string;
   let timeoutProxyURL: string;
+  let idleProxyURL: string;
   beforeAll(async () => {
     // Upstream echo server (crossws node adapter)
     const upstream = nodeAdapter({
@@ -128,6 +130,20 @@ describe("createWebSocketProxy", () => {
     timeoutProxyURL = `ws://localhost:${timeoutProxyPort}/`;
     await new Promise<void>((resolve) => timeoutProxyServer.listen(timeoutProxyPort, resolve));
     await waitForPort(timeoutProxyPort);
+
+    // Proxy with a short client-inactivity timeout
+    const idleProxy = nodeAdapter({
+      hooks: createWebSocketProxy({
+        target: upstreamURL,
+        clientIdleTimeout: 80,
+      }),
+    });
+    idleProxyServer = createServer((_req, res) => res.end("ok"));
+    idleProxyServer.on("upgrade", idleProxy.handleUpgrade);
+    const idleProxyPort = await getRandomPort("localhost");
+    idleProxyURL = `ws://localhost:${idleProxyPort}/`;
+    await new Promise<void>((resolve) => idleProxyServer.listen(idleProxyPort, resolve));
+    await waitForPort(idleProxyPort);
   });
 
   afterAll(() => {
@@ -137,6 +153,7 @@ describe("createWebSocketProxy", () => {
       limitedProxyServer,
       badProxyServer,
       timeoutProxyServer,
+      idleProxyServer,
       upstreamServer,
     ]) {
       server.closeAllConnections?.();
@@ -450,6 +467,33 @@ describe("createWebSocketProxy", () => {
     await ws.send("aaaaa");
     const event = await closed;
     expect(event.code).toBe(1009);
+  });
+
+  test("closes an idle client with 1001 after clientIdleTimeout", async () => {
+    // The client stays silent after connecting. Upstream→client traffic (the
+    // "welcome" frame) must NOT keep it alive — only client→proxy frames do —
+    // so the inactivity watchdog fires and closes with 1001.
+    const ws = await wsConnect(idleProxyURL, { skip: 1 });
+    const event = await new Promise<CloseEvent>((resolve) => {
+      ws.ws.addEventListener("close", (e) => resolve(e as CloseEvent));
+    });
+    expect(event.code).toBe(1001);
+  });
+
+  test("client traffic resets the inactivity timer", async () => {
+    const ws = await wsConnect(idleProxyURL, { skip: 1 });
+    let closed = false;
+    ws.ws.addEventListener("close", () => {
+      closed = true;
+    });
+    // Each gap is under the 80ms idle window, but the total span is well past
+    // it — the connection must stay open because every send resets the timer.
+    for (let i = 0; i < 4; i++) {
+      await new Promise((r) => setTimeout(r, 40));
+      await ws.send(`ping${i}`);
+      expect(await ws.next()).toBe(`echo:ping${i}`);
+    }
+    expect(closed).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

Adds an opt-in `clientIdleTimeout` option to `createWebSocketProxy` that closes both the peer and the upstream connection (close code `1001`) after a window of **client→proxy** inactivity.

Transport-level ping/pong keepalive doesn't always catch a client that has gone away: when there's a proxy or tunnel in the middle (an L7 gateway, an SSH/dev tunnel, a service-worker proxy), that middlebox can answer the pings itself, so the connection keeps looking healthy while no real client is attached — leaving the upstream socket dangling. `clientIdleTimeout` watches **real application frames** instead, so it reclaims those connections.

## Behavior

- Reset by every inbound client frame; **unaffected** by upstream→client traffic.
- On timeout, closes the peer with `1001` and tears down the upstream.
- Only suitable for protocols where the client sends traffic periodically (e.g. a heartbeat). For server-push-only protocols where the client may be legitimately silent, leave it disabled.
- **Disabled by default** (`0`).
- Named `clientIdleTimeout` (not `idleTimeout`) to avoid colliding with the existing adapter-level `idleTimeout` (transport ping/pong keepalive, in seconds).

```ts
createWebSocketProxy({
  target: "wss://backend.example.com",
  clientIdleTimeout: 60_000, // close a client that sends nothing for 60s
});
```

## Changes

- `src/proxy.ts` — new option + re-arming inactivity watchdog, cleared on every exit path.
- `test/proxy.test.ts` — covers timeout firing on a silent client (welcome frame does not keep it alive) and client traffic resetting the timer.
- `docs/1.guide/8.proxy.md` — new "Client idle timeout" section + API entry.

## Test plan

- [x] `pnpm vitest run test/proxy.test.ts` — 31 passed, no type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an optional client idle timeout for WebSocket proxies.
  - Automatically closes inactive client connections and their upstream connection with close code `1001`.
  - Client activity resets the timeout; the setting is disabled by default.

- **Documentation**
  - Added configuration guidance, usage examples, and recommendations for enabling client idle timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->